### PR TITLE
fix: cast auth.uid to text in receipts policy

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -124,7 +124,7 @@ begin
     create policy "receipts owner read"
       on storage.objects
       for select
-      using (bucket_id = 'receipts' and owner_id = auth.uid());
+      using (bucket_id = 'receipts' and owner_id = auth.uid()::text);
 
     create policy "receipts owner write"
       on storage.objects


### PR DESCRIPTION
## Summary
- cast auth.uid() to text in receipts owner read policy to resolve text/uuid comparison

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "prettier" to extend from)*
- `npm run typecheck` *(fails: multiple TS1136/TS1005 errors in app/api files)*

------
https://chatgpt.com/codex/tasks/task_e_689acc87350c8330964fd96575f76f4d