### PR TITLE
Replace Next.js TypeScript config with mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  reactStrictMode: true,
-}
-
-export default nextConfig


### PR DESCRIPTION
## Summary
- replace unsupported next.config.ts with next.config.mjs using ESM export

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "prettier" to extend from)*
- `npm run typecheck` *(fails: TypeScript errors in app/api routes)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689ad0e3ad6c8330815d2abecd36868a