### PR TITLE
fix: correct global CSS path

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,10 @@
-import './globals.css'
-import type { Metadata } from 'next'
+import "../styles/globals.css";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: process.env.NEXT_PUBLIC_APP_NAME || 'SpendWise',
-  description: 'Mobile-first expense tracker',
-}
+  title: process.env.NEXT_PUBLIC_APP_NAME || "SpendWise",
+  description: "Mobile-first expense tracker",
+};
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -13,5 +13,5 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {children}
       </body>
     </html>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- fix global CSS import path in layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error: Property assignment expected)*
- `npm run typecheck` *(fails: Property assignment expected)*
- `npm run build` *(fails: Module not found: Can't resolve '@/lib/supabase/client')*

------
https://chatgpt.com/codex/tasks/task_e_689ad24875448330bc320a9d68afacd2