### PR TITLE
Fix Supabase middleware client

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,15 +1,40 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
-import { createMiddlewareClient } from '@supabase/ssr'
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next()
-  const supabase = createMiddlewareClient({ req, res })
-  const { data: { session } } = await supabase.auth.getSession()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return req.cookies.get(name)?.value
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          res.cookies.set({ name, value, ...options })
+        },
+        remove(name: string, options: CookieOptions) {
+          res.cookies.set({ name, value: '', ...options })
+        },
+      },
+    }
+  )
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
   const url = new URL(req.url)
 
-  const isAuthRoute = url.pathname.startsWith('/login') || url.pathname.startsWith('/auth')
-  const isProtected = url.pathname.startsWith('/dashboard') || url.pathname.startsWith('/expenses') || url.pathname.startsWith('/categories') || url.pathname.startsWith('/accounts') || url.pathname.startsWith('/settings') || url.pathname.startsWith('/exports')
+  const isAuthRoute =
+    url.pathname.startsWith('/login') || url.pathname.startsWith('/auth')
+  const isProtected =
+    url.pathname.startsWith('/dashboard') ||
+    url.pathname.startsWith('/expenses') ||
+    url.pathname.startsWith('/categories') ||
+    url.pathname.startsWith('/accounts') ||
+    url.pathname.startsWith('/settings') ||
+    url.pathname.startsWith('/exports')
 
   if (isProtected && !session) {
     const loginUrl = new URL('/login', req.url)


### PR DESCRIPTION
## Summary
- use `createServerClient` with cookie helpers in `middleware.ts`

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "prettier" to extend from)*
- `npm run typecheck` *(fails: TypeScript errors in app/api routes)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689ad376a7088330bb2d304defae2299