### PR TITLE
fix path alias for supabase client imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,9 @@
       }
     ],
     "baseUrl": ".",
-    "paths": {}
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- map `@` to project root in `tsconfig`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the config "prettier")*
- `npm run typecheck` *(fails: TS errors in app/api/accounts and app/api/categories)*
- `npm run build` *(fails: webpack errors in app/api routes)*

------
https://chatgpt.com/codex/tasks/task_e_689ad52268e4833097bb44bb813a7dd5