### PR TITLE
Add vendor field to expense creation

### DIFF
--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -8,13 +8,14 @@ export default function NewExpensePage() {
   const [currency, setCurrency] = useState(process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || 'AUD')
   const [occurred_on, setOccurredOn] = useState(new Date().toISOString().slice(0,10))
   const [description, setDescription] = useState('')
+  const [vendor, setVendor] = useState('')
   const router = useRouter()
 
   const submit = async () => {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) return
     const { error } = await supabase.from('expenses').insert({
-      user_id: user.id, amount: Number(amount || 0), currency, occurred_on, description
+      user_id: user.id, amount: Number(amount || 0), currency, occurred_on, description, vendor
     })
     if (!error) router.push('/dashboard')
   }
@@ -26,6 +27,7 @@ export default function NewExpensePage() {
         <input placeholder="Amount" value={amount} onChange={e=>setAmount(e.target.value)} />
         <input placeholder="Currency (e.g., AUD)" value={currency} onChange={e=>setCurrency(e.target.value.toUpperCase())} />
         <input type="date" value={occurred_on} onChange={e=>setOccurredOn(e.target.value)} />
+        <input placeholder="Vendor" value={vendor} onChange={e=>setVendor(e.target.value)} />
         <input placeholder="Description" value={description} onChange={e=>setDescription(e.target.value)} />
         <button onClick={submit} className="bg-black text-white py-2 rounded-md">Save</button>
       </div>

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -1,6 +1,6 @@
 export function toCsv(rows: any[]): string {
   const headers = [
-    'date','amount','currency','description','category','account','receipt_path','is_exported','export_id'
+    'date','amount','currency','description','vendor','category','account','receipt_path','is_exported','export_id'
   ]
   const esc = (v: any) => {
     if (v === null || v === undefined) return ''
@@ -10,7 +10,7 @@ export function toCsv(rows: any[]): string {
   const lines = [headers.join(',')]
   for (const r of rows) {
     lines.push([
-      r.occurred_on, r.amount, r.currency, r.description ?? '', r.category ?? '',
+      r.occurred_on, r.amount, r.currency, r.description ?? '', r.vendor ?? '', r.category ?? '',
       r.account ?? '', r.receipt_path ?? '', r.is_exported ?? false, r.export_id ?? ''
     ].map(esc).join(','))
   }

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -5,6 +5,7 @@ export const expenseSchema = z.object({
   currency: z.string().length(3).transform((s) => s.toUpperCase()),
   occurred_on: z.string(), // 'YYYY-MM-DD'
   description: z.string().max(500).optional().nullable(),
+  vendor: z.string().max(200).optional().nullable(),
   category_id: z.string().uuid().optional().nullable(),
   account_id: z.string().uuid().optional().nullable(),
   receipt_filename: z.string().optional().nullable(),

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -77,6 +77,7 @@ CREATE TABLE IF NOT EXISTS public.expenses (
   amount NUMERIC(12,2) NOT NULL,
   currency public.currency_code NOT NULL DEFAULT 'AUD',
   description TEXT,
+  vendor TEXT,
   category TEXT,
   export_id UUID,  -- Reference to export if needed
   receipt_url TEXT,


### PR DESCRIPTION
## Summary
- add `vendor` column to expenses table schema
- capture vendor in new expense form and submissions
- include vendor in CSV exports and validation schema

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the config "prettier")*
- `npm run typecheck` *(fails: Property assignment expected)*

------
https://chatgpt.com/codex/tasks/task_e_689ad816e7508330a7c8a4e2022ef2d0