### PR TITLE
Add quick stats expense links

### DIFF
--- a/app/(app)/expenses/[id]/page.tsx
+++ b/app/(app)/expenses/[id]/page.tsx
@@ -1,0 +1,22 @@
+import { serverClient } from '@/lib/supabase/server'
+import { redirect, notFound } from 'next/navigation'
+
+export default async function ExpensePage({ params }: { params: { id: string } }) {
+  const supabase = serverClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+  const { data } = await supabase.from('expenses').select('*').eq('id', params.id).eq('user_id', user.id).single()
+  if (!data) notFound()
+
+  return (
+    <main className="container py-6">
+      <h1 className="text-xl font-semibold mb-4">Expense</h1>
+      <div className="card space-y-2">
+        <p>Amount: {data.amount} {data.currency}</p>
+        <p>Date: {data.occurred_on?.slice(0, 10)}</p>
+        {data.vendor && <p>Vendor: {data.vendor}</p>}
+        {data.description && <p>Description: {data.description}</p>}
+      </div>
+    </main>
+  )
+}

--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -20,7 +20,7 @@ export default function NewExpensePage() {
       user_id: user.id,
       amount: Number(amount || 0),
       currency,
-      date: new Date(date).toISOString(),
+      occurred_on: date,
       description,
       vendor,
     });


### PR DESCRIPTION
## Summary
- ensure new expense uses `occurred_on` for correct dashboard totals
- show recent expenses on dashboard with links to view details
- add expense detail page to inspect an individual expense

## Testing
- `npm run lint` *(fails: Parsing error in app/api/accounts/route.ts)*
- `npm run typecheck` *(fails: Property assignment expected in app/api/accounts/route.ts)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689add966644833081d99d7f53902ffa