### PR TITLE
Use date column for expenses

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -15,11 +15,11 @@ export default async function DashboardPage() {
   const end = ym + '-31'
   const { data: monthExpenses } = await supabase
     .from('expenses')
-    .select('id, description, vendor, amount, currency, occurred_on')
+    .select('id, description, vendor, amount, currency, date')
     .eq('user_id', user.id)
-    .gte('occurred_on', start)
-    .lte('occurred_on', end)
-    .order('occurred_on', { ascending: false })
+    .gte('date', start)
+    .lte('date', end)
+    .order('date', { ascending: false })
 
   const total = monthExpenses?.reduce((sum: number, e: any) => sum + e.amount, 0) ?? 0
   const recent = monthExpenses?.slice(0,5) ?? []

--- a/app/(app)/expenses/[id]/page.tsx
+++ b/app/(app)/expenses/[id]/page.tsx
@@ -13,7 +13,7 @@ export default async function ExpensePage({ params }: { params: { id: string } }
       <h1 className="text-xl font-semibold mb-4">Expense</h1>
       <div className="card space-y-2">
         <p>Amount: {data.amount} {data.currency}</p>
-        <p>Date: {data.occurred_on?.slice(0, 10)}</p>
+        <p>Date: {data.date?.slice(0, 10)}</p>
         {data.vendor && <p>Vendor: {data.vendor}</p>}
         {data.description && <p>Description: {data.description}</p>}
       </div>

--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -20,7 +20,7 @@ export default function NewExpensePage() {
       user_id: user.id,
       amount: Number(amount || 0),
       currency,
-      occurred_on: date,
+      date,
       description,
       vendor,
     });

--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -10,13 +10,13 @@ export async function GET(req: Request) {
   const month = url.searchParams.get('month')
   const includeExported = url.searchParams.get('includeExported') === 'true'
 
-  let query = supabase.from('expenses').select('*').eq('user_id', user.id).order('occurred_on', { ascending: false })
+  let query = supabase.from('expenses').select('*').eq('user_id', user.id).order('date', { ascending: false })
   if (month) {
     const start = month + '-01'
     const end = month + '-31'
-    query = query.gte('occurred_on', start).lte('occurred_on', end)
+    query = query.gte('date', start).lte('date', end)
   }
-  if (!includeExported) query = query.eq('is_exported', false)
+  if (!includeExported) query = query.is('export_id', null)
   const { data, error } = await query
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
   return NextResponse.json(data)

--- a/app/api/export/csv/route.ts
+++ b/app/api/export/csv/route.ts
@@ -15,10 +15,10 @@ export async function GET(req: Request) {
 
   const { data, error } = await supabase
     .from('expenses')
-    .select('id, amount, currency, occurred_on, description, receipt_path, is_exported, export_id')
+    .select('id, amount, currency, date, description, vendor, category, receipt_url, export_id')
     .eq('user_id', user.id)
-    .gte('occurred_on', start).lte('occurred_on', end)
-    .order('occurred_on', { ascending: true })
+    .gte('date', start).lte('date', end)
+    .order('date', { ascending: true })
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
 
   const csv = toCsv((data || []).map((r:any)=>({ ...r })))

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -1,6 +1,6 @@
 export function toCsv(rows: any[]): string {
   const headers = [
-    'date','amount','currency','description','vendor','category','account','receipt_path','is_exported','export_id'
+    'date','amount','currency','description','vendor','category','receipt_url','export_id'
   ]
   const esc = (v: any) => {
     if (v === null || v === undefined) return ''
@@ -10,8 +10,8 @@ export function toCsv(rows: any[]): string {
   const lines = [headers.join(',')]
   for (const r of rows) {
     lines.push([
-      r.occurred_on, r.amount, r.currency, r.description ?? '', r.vendor ?? '', r.category ?? '',
-      r.account ?? '', r.receipt_path ?? '', r.is_exported ?? false, r.export_id ?? ''
+      r.date, r.amount, r.currency, r.description ?? '', r.vendor ?? '', r.category ?? '',
+      r.receipt_url ?? '', r.export_id ?? ''
     ].map(esc).join(','))
   }
   return lines.join('\r\n')

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 export const expenseSchema = z.object({
   amount: z.number().nonnegative(),
   currency: z.string().length(3).transform((s) => s.toUpperCase()),
-  occurred_on: z.string(), // 'YYYY-MM-DD'
+  date: z.string(), // 'YYYY-MM-DD'
   description: z.string().max(500).optional().nullable(),
   vendor: z.string().max(200).optional().nullable(),
   category_id: z.string().uuid().optional().nullable(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "autoprefixer": "^10.4.19",
         "eslint": "^8.57.0",
         "eslint-config-next": "14.2.5",
+        "eslint-config-prettier": "^10.1.8",
         "postcss": "^8.4.38",
         "prettier": "^3.3.3",
         "tailwindcss": "^3.4.7",
@@ -2305,6 +2306,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -10,26 +10,27 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "14.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "@supabase/supabase-js": "^2.45.0",
     "@supabase/ssr": "^0.4.0",
-    "zod": "^3.23.8",
-    "react-hook-form": "^7.52.1",
+    "@supabase/supabase-js": "^2.45.0",
     "date-fns": "^3.6.0",
     "jszip": "^3.10.1",
-    "pdf-lib": "^1.17.1"
+    "next": "14.2.5",
+    "pdf-lib": "^1.17.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-hook-form": "^7.52.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
-    "typescript": "^5.4.5",
-    "tailwindcss": "^3.4.7",
-    "postcss": "^8.4.38",
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.66",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
-    "prettier": "^3.3.3",
     "eslint-config-next": "14.2.5",
-    "@types/node": "^20.12.7",
-    "@types/react": "^18.2.66"
+    "eslint-config-prettier": "^10.1.8",
+    "postcss": "^8.4.38",
+    "prettier": "^3.3.3",
+    "tailwindcss": "^3.4.7",
+    "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- insert expenses using the `date` column instead of the removed `occurred_on`
- query expenses by `date` across dashboard and API routes
- update CSV/export utilities and validation to match new schema

## Testing
- `npm run lint` *(fails: Parsing error in app/api/accounts/route.ts)*
- `npm run typecheck` *(fails: TS errors in app/api/accounts/route.ts and app/api/categories/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689ae5169cec83308364a1eef0360468