### PR TITLE
feat: card layout for expenses with sliding exports pane

### DIFF
--- a/app/(app)/expenses/ExportsPane.tsx
+++ b/app/(app)/expenses/ExportsPane.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function ExportsPane() {
+  const [open, setOpen] = useState(false)
+  const [exports, setExports] = useState<any[]>([])
+
+  useEffect(() => {
+    if (open) {
+      fetch('/api/exports')
+        .then((res) => res.json())
+        .then(setExports)
+    }
+  }, [open])
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)} className="underline">Exports</button>
+      <div className={`fixed top-0 right-0 h-full w-80 bg-white border-l shadow-lg transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}>
+        <div className="p-4 h-full flex flex-col">
+          <button onClick={() => setOpen(false)} className="underline mb-2">Close</button>
+          <h2 className="font-semibold mb-4">Export history</h2>
+          <div className="space-y-2 overflow-y-auto">
+            {exports.map((e: any) => (
+              <div key={e.id} className="card">
+                <div>Period: {e.period_start} → {e.period_end}</div>
+                <div>Items: {e.items_count} • Total: {e.total_amount} {e.currency}</div>
+              </div>
+            ))}
+            {!exports.length && <p className="text-sm text-neutral-600">No exports</p>}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/(app)/expenses/page.tsx
+++ b/app/(app)/expenses/page.tsx
@@ -1,0 +1,37 @@
+import UserHeader from '@/components/UserHeader'
+import { serverClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import ExportsPane from './ExportsPane'
+
+export const revalidate = 0
+
+export default async function ExpensesPage() {
+  const supabase = serverClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+  const { data: expenses } = await supabase
+    .from('expenses')
+    .select('id, vendor, description, amount, currency, date')
+    .eq('user_id', user.id)
+    .order('date', { ascending: false })
+
+  return (
+    <main className="container py-6">
+      <UserHeader />
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-xl font-semibold">Expenses</h1>
+        <ExportsPane />
+      </div>
+      <div className="space-y-2">
+        {(expenses ?? []).map((e: any) => (
+          <div key={e.id} className="card space-y-1">
+            <div>Vendor: {e.vendor || '—'}</div>
+            <div>Description: {e.description || '—'}</div>
+            <div>Amount: {e.amount} {e.currency}</div>
+            <div>Date: {e.date?.slice(0, 10)}</div>
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -5,7 +5,11 @@ export async function GET() {
   const supabase = serverClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return new NextResponse('Unauthorized', { status: 401 })
-  const { data, error } = await supabase.from('accounts').select('*').eq('user_id', user.id).order('created_at', {{ ascending: false }})
+  const { data, error } = await supabase
+    .from('accounts')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
   return NextResponse.json(data)
 }
@@ -15,7 +19,7 @@ export async function POST(req: Request) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return new NextResponse('Unauthorized', { status: 401 })
   const body = await req.json()
-  const insert = {{ ...body, user_id: user.id }}
+  const insert = { ...body, user_id: user.id }
   const { data, error } = await supabase.from('accounts').insert(insert).select().single()
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })
   return NextResponse.json(data, { status: 201 })

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -5,7 +5,11 @@ export async function GET() {
   const supabase = serverClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return new NextResponse('Unauthorized', { status: 401 })
-  const { data, error } = await supabase.from('categories').select('*').eq('user_id', user.id).order('created_at', {{ ascending: false }})
+  const { data, error } = await supabase
+    .from('categories')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
   return NextResponse.json(data)
 }
@@ -15,7 +19,7 @@ export async function POST(req: Request) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return new NextResponse('Unauthorized', { status: 401 })
   const body = await req.json()
-  const insert = {{ ...body, user_id: user.id }}
+  const insert = { ...body, user_id: user.id }
   const { data, error } = await supabase.from('categories').insert(insert).select().single()
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })
   return NextResponse.json(data, { status: 201 })


### PR DESCRIPTION
## Summary
- list expenses as cards showing vendor, description, amount and date
- slide-in exports pane hidden by default
- fix malformed accounts and categories API routes to satisfy lint

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ae82482108330a191ea46da898242