### PR TITLE
feat: show expense rows with clickable date and amount

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -32,11 +32,18 @@ export default async function DashboardPage() {
           <h2 className="font-semibold mb-2">Quick stats</h2>
           <p className="text-sm text-neutral-600">Month: {ym}</p>
           <p className="text-sm">Total: {total}</p>
-          <ul className="mt-2 space-y-1">
+          <ul className="mt-2 divide-y">
             {recent.map((e: any) => (
-              <li key={e.id}>
+              <li key={e.id} className="grid grid-cols-3 items-center py-2 gap-2">
+                <span>{e.vendor || e.description || '—'}</span>
                 <Link className="underline" href={`/expenses/${e.id}`}>
-                  {e.vendor || e.description || 'View expense'}
+                  {e.date?.slice(0, 10)}
+                </Link>
+                <Link
+                  className="underline justify-self-end"
+                  href={`/expenses/${e.id}`}
+                >
+                  {e.amount} {e.currency}
                 </Link>
               </li>
             ))}

--- a/app/(app)/expenses/page.tsx
+++ b/app/(app)/expenses/page.tsx
@@ -2,6 +2,7 @@ import UserHeader from '@/components/UserHeader'
 import { serverClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import ExportsPane from './ExportsPane'
+import Link from 'next/link'
 
 export const revalidate = 0
 
@@ -22,13 +23,19 @@ export default async function ExpensesPage() {
         <h1 className="text-xl font-semibold">Expenses</h1>
         <ExportsPane />
       </div>
-      <div className="space-y-2">
+      <div className="divide-y">
         {(expenses ?? []).map((e: any) => (
-          <div key={e.id} className="card space-y-1">
-            <div>Vendor: {e.vendor || '—'}</div>
-            <div>Description: {e.description || '—'}</div>
-            <div>Amount: {e.amount} {e.currency}</div>
-            <div>Date: {e.date?.slice(0, 10)}</div>
+          <div
+            key={e.id}
+            className="grid grid-cols-3 items-center py-2 gap-4"
+          >
+            <span>{e.vendor || e.description || '—'}</span>
+            <Link className="underline" href={`/expenses/${e.id}`}>
+              {e.date?.slice(0, 10)}
+            </Link>
+            <Link className="underline justify-self-end" href={`/expenses/${e.id}`}>
+              {e.amount} {e.currency}
+            </Link>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- display each expense as a grid row with vendor plus clickable date and amount
- show recent dashboard expenses with same row layout

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689aed80130c83309c70c810f73d9f55