### PR TITLE
Style add expense link as dashboard button

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -48,7 +48,12 @@ export default async function DashboardPage() {
               </li>
             ))}
           </ul>
-          <a className="underline mt-2 inline-block" href="/expenses/new">Add expense</a>
+          <Link
+            href="/expenses/new"
+            className="bg-black text-white py-2 rounded-md block text-center mt-2"
+          >
+            Add expense
+          </Link>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- Restyle dashboard's "Add expense" control as a button at the bottom of the Quick stats card, matching the save button styling on the add expense screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689aefdfbc108330b1150ba60c357a65