### PR TITLE
Make expenses editable and vendor/description links clickable

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -43,8 +43,12 @@ export default async function DashboardPage() {
                 <Link className="underline" href={`/expenses/${e.id}`}>
                   {e.date?.slice(0, 10)}
                 </Link>
-                <span>{e.vendor || '—'}</span>
-                <span>{e.description || '—'}</span>
+                <Link className="underline" href={`/expenses/${e.id}`}>
+                  {e.vendor || '—'}
+                </Link>
+                <Link className="underline" href={`/expenses/${e.id}`}>
+                  {e.description || '—'}
+                </Link>
                 <Link
                   className="underline justify-self-end"
                   href={`/expenses/${e.id}`}

--- a/app/(app)/expenses/[id]/page.tsx
+++ b/app/(app)/expenses/[id]/page.tsx
@@ -1,22 +1,103 @@
-import { serverClient } from '@/lib/supabase/server'
-import { redirect, notFound } from 'next/navigation'
+"use client";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
 
-export default async function ExpensePage({ params }: { params: { id: string } }) {
-  const supabase = serverClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) redirect('/login')
-  const { data } = await supabase.from('expenses').select('*').eq('id', params.id).eq('user_id', user.id).single()
-  if (!data) notFound()
+export default function EditExpensePage({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const router = useRouter();
+  const [amount, setAmount] = useState("");
+  const [currency, setCurrency] = useState(
+    process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || "AUD"
+  );
+  const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
+  const [description, setDescription] = useState("");
+  const [vendor, setVendor] = useState("");
+
+  useEffect(() => {
+    const load = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) {
+        router.push("/login");
+        return;
+      }
+      const { data } = await supabase
+        .from("expenses")
+        .select("*")
+        .eq("id", id)
+        .eq("user_id", user.id)
+        .single();
+      if (!data) {
+        router.push("/expenses");
+        return;
+      }
+      setAmount(String(data.amount ?? ""));
+      setCurrency(data.currency || process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || "AUD");
+      setDate(data.date?.slice(0, 10) || new Date().toISOString().slice(0, 10));
+      setVendor(data.vendor || "");
+      setDescription(data.description || "");
+    };
+    load();
+  }, [id, router]);
+
+  const submit = async () => {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+    const { error } = await supabase
+      .from("expenses")
+      .update({
+        amount: Number(amount || 0),
+        currency,
+        date,
+        description,
+        vendor,
+      })
+      .eq("id", id)
+      .eq("user_id", user.id);
+    if (!error) router.push("/expenses");
+  };
 
   return (
     <main className="container py-6">
-      <h1 className="text-xl font-semibold mb-4">Expense</h1>
-      <div className="card space-y-2">
-        <p>Amount: {data.amount} {data.currency}</p>
-        <p>Date: {data.date?.slice(0, 10)}</p>
-        {data.vendor && <p>Vendor: {data.vendor}</p>}
-        {data.description && <p>Description: {data.description}</p>}
+      <h1 className="text-xl font-semibold mb-4">Edit expense</h1>
+      <div className="card space-y-3">
+        <input
+          placeholder="Amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+        <input
+          placeholder="Currency (e.g., AUD)"
+          value={currency}
+          onChange={(e) => setCurrency(e.target.value.toUpperCase())}
+        />
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+        <input
+          placeholder="Vendor"
+          value={vendor}
+          onChange={(e) => setVendor(e.target.value)}
+        />
+        <input
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <button
+          onClick={submit}
+          className="bg-black text-white py-2 rounded-md"
+        >
+          Save
+        </button>
       </div>
     </main>
-  )
+  );
 }
+

--- a/app/(app)/expenses/page.tsx
+++ b/app/(app)/expenses/page.tsx
@@ -37,8 +37,12 @@ export default async function ExpensesPage() {
             <Link className="underline" href={`/expenses/${e.id}`}>
               {e.date?.slice(0, 10)}
             </Link>
-            <span>{e.vendor || '—'}</span>
-            <span>{e.description || '—'}</span>
+            <Link className="underline" href={`/expenses/${e.id}`}>
+              {e.vendor || '—'}
+            </Link>
+            <Link className="underline" href={`/expenses/${e.id}`}>
+              {e.description || '—'}
+            </Link>
             <Link className="underline justify-self-end" href={`/expenses/${e.id}`}>
               {aud.format(e.amount)}
             </Link>


### PR DESCRIPTION
## Summary
- Allow editing an expense with a new client-side form at `/expenses/[id]`
- Make vendor and description clickable in expenses and dashboard lists

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689af53485e4833095280984b9eade1f