### PR TITLE
Add dropdown for entity management

### DIFF
--- a/app/(app)/vendors/page.tsx
+++ b/app/(app)/vendors/page.tsx
@@ -1,0 +1,17 @@
+import { serverClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+
+export default async function VendorsPage() {
+  const supabase = serverClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+  const { data } = await supabase.from('vendors').select('*').order('created_at', { ascending: false })
+  return (
+    <main className="container py-6">
+      <h1 className="text-xl font-semibold mb-4">Vendors</h1>
+      <div className="space-y-2">
+        {(data ?? []).map((v:any)=> <div key={v.id} className="card">{v.name}</div>)}
+      </div>
+    </main>
+  )
+}

--- a/components/EntitiesMenu.tsx
+++ b/components/EntitiesMenu.tsx
@@ -1,0 +1,12 @@
+export default function EntitiesMenu() {
+  return (
+    <details className="relative">
+      <summary className="px-3 py-2 rounded-md border cursor-pointer select-none">Entities</summary>
+      <div className="absolute right-0 mt-2 w-48 bg-white border rounded-md shadow-md z-10">
+        <a href="/vendors" className="block px-4 py-2 hover:bg-neutral-100">Vendors</a>
+        <a href="/categories" className="block px-4 py-2 hover:bg-neutral-100">Categories</a>
+        <a href="/accounts" className="block px-4 py-2 hover:bg-neutral-100">Accounts</a>
+      </div>
+    </details>
+  )
+}

--- a/components/UserHeader.tsx
+++ b/components/UserHeader.tsx
@@ -1,4 +1,5 @@
 import LogoutButton from './LogoutButton'
+import EntitiesMenu from './EntitiesMenu'
 import { serverClient } from '@/lib/supabase/server'
 
 export default async function UserHeader() {
@@ -13,7 +14,10 @@ export default async function UserHeader() {
         <div className="font-medium">{name}</div>
         <div className="text-xs text-neutral-500">{email}</div>
       </div>
-      <LogoutButton />
+      <div className="flex items-center gap-2">
+        <EntitiesMenu />
+        <LogoutButton />
+      </div>
     </div>
   )
 }

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -6,6 +6,7 @@ export const expenseSchema = z.object({
   date: z.string(), // 'YYYY-MM-DD'
   description: z.string().max(500).optional().nullable(),
   vendor: z.string().max(200).optional().nullable(),
+  vendor_id: z.string().uuid().optional().nullable(),
   category_id: z.string().uuid().optional().nullable(),
   account_id: z.string().uuid().optional().nullable(),
   receipt_filename: z.string().optional().nullable(),

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -70,6 +70,48 @@ CREATE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
 
+-- Accounts table
+CREATE TABLE IF NOT EXISTS public.accounts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.accounts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own accounts" ON public.accounts FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own accounts" ON public.accounts FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own accounts" ON public.accounts FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can delete own accounts" ON public.accounts FOR DELETE USING (auth.uid() = user_id);
+
+-- Categories table
+CREATE TABLE IF NOT EXISTS public.categories (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.categories ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own categories" ON public.categories FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own categories" ON public.categories FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own categories" ON public.categories FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can delete own categories" ON public.categories FOR DELETE USING (auth.uid() = user_id);
+
+-- Vendors table
+CREATE TABLE IF NOT EXISTS public.vendors (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.vendors ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can view own vendors" ON public.vendors FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own vendors" ON public.vendors FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own vendors" ON public.vendors FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can delete own vendors" ON public.vendors FOR DELETE USING (auth.uid() = user_id);
+
 -- Expenses table creation
 CREATE TABLE IF NOT EXISTS public.expenses (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -79,6 +121,9 @@ CREATE TABLE IF NOT EXISTS public.expenses (
   description TEXT,
   vendor TEXT,
   category TEXT,
+  vendor_id UUID REFERENCES public.vendors(id),
+  category_id UUID REFERENCES public.categories(id),
+  account_id UUID REFERENCES public.accounts(id),
   export_id UUID,  -- Reference to export if needed
   receipt_url TEXT,
   date TIMESTAMPTZ DEFAULT NOW(),

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,3 +1,4 @@
 -- Optional seed (example only)
 -- insert into categories (user_id, name) values ('00000000-0000-0000-0000-000000000000', 'Meals');
 -- insert into accounts (user_id, name) values ('00000000-0000-0000-0000-000000000000', 'Corporate Card');
+-- insert into vendors (user_id, name) values ('00000000-0000-0000-0000-000000000000', 'Acme Inc.');


### PR DESCRIPTION
## Summary
- add Entities dropdown menu beside logout linking to Vendors, Categories, and Accounts pages
- scaffold Vendors page and Supabase tables for vendors, categories, and accounts with expense references
- include vendor_id validation and seed example

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: useSearchParams() should be wrapped in a suspense boundary at page "/login". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)*

------
https://chatgpt.com/codex/tasks/task_e_689af76850e0833097b23a4598a48575