### PR TITLE
Use API route for adding expenses

### DIFF
--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -16,15 +16,20 @@ export default function NewExpensePage() {
       data: { user },
     } = await supabase.auth.getUser();
     if (!user) return;
-    const { error } = await supabase.from("expenses").insert({
-      user_id: user.id,
-      amount: Number(amount || 0),
-      currency,
-      date,
-      description,
-      vendor,
+
+    const res = await fetch("/api/expenses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        amount: Number(amount || 0),
+        currency,
+        date,
+        description,
+        vendor,
+      }),
     });
-    if (!error) router.push("/dashboard");
+
+    if (res.ok) router.push("/dashboard");
   };
 
   return (


### PR DESCRIPTION
## Summary
- route new expense submissions through internal API endpoint to avoid 403s

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bd1c2fe88833092cc71f589a7b601