### PR TITLE
Fix new expense POST by sending credentials and ISO date

### DIFF
--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -23,10 +23,13 @@ export default function NewExpensePage() {
       body: JSON.stringify({
         amount: Number(amount || 0),
         currency,
-        date,
+        // ensure the date is in ISO format to satisfy the API/DB
+        date: new Date(date).toISOString(),
         description,
         vendor,
       }),
+      // send authentication cookies with the request
+      credentials: "include",
     });
 
     if (res.ok) router.push("/dashboard");


### PR DESCRIPTION
## Summary
- include auth cookies in new expense POST requests
- convert date to ISO format before sending to the API

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bd407b84c83309c490d2822194801