### PR TITLE
Validate expense input before submitting

### DIFF
--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -17,14 +17,17 @@ export default function NewExpensePage() {
     } = await supabase.auth.getUser();
     if (!user) return;
 
+    const parsedAmount = parseFloat(amount);
+    const parsedDate = new Date(date);
+
     const res = await fetch("/api/expenses", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        amount: Number(amount || 0),
+        amount: isNaN(parsedAmount) ? 0 : parsedAmount,
         currency,
         // ensure the date is in ISO format to satisfy the API/DB
-        date: new Date(date).toISOString(),
+        date: isNaN(parsedDate.getTime()) ? new Date().toISOString() : parsedDate.toISOString(),
         description,
         vendor,
       }),
@@ -32,7 +35,12 @@ export default function NewExpensePage() {
       credentials: "include",
     });
 
-    if (res.ok) router.push("/dashboard");
+    if (res.ok) {
+      router.push("/dashboard");
+    } else {
+      // surface error for easier debugging
+      console.error("Failed to save expense", await res.json());
+    }
   };
 
   return (

--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -27,11 +27,23 @@ export async function POST(req: Request) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return new NextResponse('Unauthorized', { status: 401 })
   const body = await req.json()
+
+  // validate and normalise amount
+  const amount = Number(body.amount)
+  if (!Number.isFinite(amount)) {
+    return NextResponse.json({ error: 'Invalid amount' }, { status: 400 })
+  }
+
+  // validate and normalise date
+  const dateObj = new Date(body.date)
+  if (isNaN(dateObj.getTime())) {
+    return NextResponse.json({ error: 'Invalid date' }, { status: 400 })
+  }
+
   const insert = {
     ...body,
-    // ensure numeric and date types are stored correctly
-    amount: Number(body.amount),
-    date: new Date(body.date).toISOString(),
+    amount,
+    date: dateObj.toISOString(),
     user_id: user.id,
   }
   const { data, error } = await supabase.from('expenses').insert(insert).select().single()


### PR DESCRIPTION
## Summary
- validate amount and date in expense POST API
- sanitize amount/date on the new expense form and log any save errors

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689bd973378c8330843139ee94f135c4