### PR TITLE
Reload dashboard after expense changes

### DIFF
--- a/app/(app)/expenses/[id]/page.tsx
+++ b/app/(app)/expenses/[id]/page.tsx
@@ -48,24 +48,24 @@ export default function EditExpensePage({ params }: { params: { id: string } }) 
     load();
   }, [id, router]);
 
-  const submit = async () => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) return;
-    const { error } = await supabase
-      .from("expenses")
-      .update({
-        amount: Number(amount || 0),
-        currency,
-        date,
-        description,
-        vendor,
-      })
-      .eq("id", id)
-      .eq("user_id", user.id);
-    if (!error) router.push("/expenses");
-  };
+    const submit = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+      const { error } = await supabase
+        .from("expenses")
+        .update({
+          amount: Number(amount || 0),
+          currency,
+          date,
+          description,
+          vendor,
+        })
+        .eq("id", id)
+        .eq("user_id", user.id);
+      if (!error) router.push("/expenses");
+    };
 
   const remove = async () => {
     if (exportId) return;
@@ -75,13 +75,16 @@ export default function EditExpensePage({ params }: { params: { id: string } }) 
       data: { user },
     } = await supabase.auth.getUser();
     if (!user) return;
-    const { error } = await supabase
-      .from("expenses")
-      .delete()
-      .eq("id", id)
-      .eq("user_id", user.id);
-    if (!error) router.push("/expenses");
-  };
+      const { error } = await supabase
+        .from("expenses")
+        .delete()
+        .eq("id", id)
+        .eq("user_id", user.id);
+      if (!error) {
+        router.push("/dashboard");
+        router.refresh();
+      }
+    };
 
   return (
     <main className="container py-6">

--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -37,6 +37,7 @@ export default function NewExpensePage() {
 
     if (res.ok) {
       router.push("/dashboard");
+      router.refresh();
     } else {
       // surface error for easier debugging
       console.error("Failed to save expense", await res.json());


### PR DESCRIPTION
## Summary
- Refresh dashboard after creating a new expense.
- Redirect to dashboard and refresh after deleting an expense to restore the Add expense button.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689be7f575b48330a7da194ae3bf2cad