### PR TITLE
Add global header for navigation and entity picker

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,0 +1,10 @@
+import Header from '@/components/Header'
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+import EntitiesMenu from './EntitiesMenu'
+
+export default function Header() {
+  return (
+    <header className="border-b mb-6">
+      <div className="container flex items-center justify-between py-4">
+        <Link href="/dashboard" className="font-semibold">
+          Dashboard
+        </Link>
+        <EntitiesMenu />
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- Add reusable Header component with dashboard link and entity picker
- Wrap application pages in new layout to display the header across pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c2e6060e08330bf0e254bde652d34