### PR TITLE
feat: allow deleting vendors without expenses

### DIFF
--- a/app/(app)/vendors/VendorsList.tsx
+++ b/app/(app)/vendors/VendorsList.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Vendor {
+  id: string
+  name: string
+  created_at: string
+  expense_count: number
+}
+
+export default function VendorsList() {
+  const [vendors, setVendors] = useState<Vendor[]>([])
+
+  const fetchVendors = () => {
+    fetch('/api/vendors')
+      .then((res) => res.json())
+      .then(setVendors)
+  }
+
+  useEffect(() => {
+    fetchVendors()
+  }, [])
+
+  const handleDelete = async (id: string) => {
+    await fetch(`/api/vendors/${id}`, { method: 'DELETE' })
+    fetchVendors()
+  }
+
+  return (
+    <div className="space-y-2">
+      {vendors.map((v) => (
+        <div key={v.id} className="card flex items-center justify-between">
+          <span>{v.name}</span>
+          {v.expense_count === 0 && (
+            <button
+              onClick={() => handleDelete(v.id)}
+              className="px-2 py-1 text-sm bg-red-500 text-white rounded"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/(app)/vendors/page.tsx
+++ b/app/(app)/vendors/page.tsx
@@ -1,17 +1,17 @@
 import { serverClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
+import VendorsList from './VendorsList'
 
 export default async function VendorsPage() {
   const supabase = serverClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
   if (!user) redirect('/login')
-  const { data } = await supabase.from('vendors').select('*').order('created_at', { ascending: false })
   return (
     <main className="container py-6">
       <h1 className="text-xl font-semibold mb-4">Vendors</h1>
-      <div className="space-y-2">
-        {(data ?? []).map((v:any)=> <div key={v.id} className="card">{v.name}</div>)}
-      </div>
+      <VendorsList />
     </main>
   )
 }

--- a/app/api/vendors/[id]/route.ts
+++ b/app/api/vendors/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+import { serverClient } from '@/lib/supabase/server'
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const supabase = serverClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return new NextResponse('Unauthorized', { status: 401 })
+
+  const { count, error: countError } = await supabase
+    .from('expenses')
+    .select('id', { count: 'exact', head: true })
+    .eq('vendor_id', params.id)
+    .eq('user_id', user.id)
+  if (countError) return NextResponse.json({ error: countError.message }, { status: 400 })
+  if (count && count > 0) {
+    return NextResponse.json({ error: 'Vendor has expenses' }, { status: 400 })
+  }
+
+  const { error } = await supabase
+    .from('vendors')
+    .delete()
+    .eq('id', params.id)
+    .eq('user_id', user.id)
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/api/vendors/route.ts
+++ b/app/api/vendors/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import { serverClient } from '@/lib/supabase/server'
+
+export async function GET() {
+  const supabase = serverClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return new NextResponse('Unauthorized', { status: 401 })
+  const { data, error } = await supabase
+    .from('vendors')
+    .select('id, name, created_at, expenses(count)')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  const mapped = (data ?? []).map((v: any) => ({
+    id: v.id,
+    name: v.name,
+    created_at: v.created_at,
+    expense_count: v.expenses?.[0]?.count ?? 0,
+  }))
+  return NextResponse.json(mapped)
+}


### PR DESCRIPTION
## Summary
- add API endpoints for listing and deleting vendors
- show delete button on vendor cards when there are no related expenses
- refresh vendor list after deletion

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c305571288330838c4799d4af8c19