### PR TITLE
style: shrink delete button width

### DIFF
--- a/app/(app)/expenses/[id]/page.tsx
+++ b/app/(app)/expenses/[id]/page.tsx
@@ -150,7 +150,7 @@ export default function EditExpensePage({ params }: { params: { id: string } }) 
           <button
             onClick={remove}
             disabled={!!exportId}
-            className="bg-red-600 text-white py-2 rounded-md disabled:opacity-50"
+            className="bg-red-600 text-white py-2 px-4 rounded-md disabled:opacity-50 w-fit"
           >
             Delete
           </button>

--- a/app/(app)/vendors/VendorsList.tsx
+++ b/app/(app)/vendors/VendorsList.tsx
@@ -35,7 +35,7 @@ export default function VendorsList() {
           {v.expense_count === 0 && (
             <button
               onClick={() => handleDelete(v.id)}
-              className="px-2 py-1 text-sm bg-red-500 text-white rounded"
+              className="px-2 py-1 text-sm bg-red-500 text-white rounded w-fit"
             >
               Delete
             </button>


### PR DESCRIPTION
## Summary
- Prevent delete buttons from stretching full width by overriding global styles with w-fit
- Adjust expense edit and vendor list delete buttons

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c31e3362083308cb7b927a2e8c859