### PR TITLE
Add category support for expenses

### DIFF
--- a/app/(app)/categories/CategoriesList.tsx
+++ b/app/(app)/categories/CategoriesList.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Category {
+  id: string
+  name: string
+  created_at: string
+  expense_count: number
+}
+
+export default function CategoriesList() {
+  const [categories, setCategories] = useState<Category[]>([])
+
+  const fetchCategories = () => {
+    fetch('/api/categories')
+      .then((res) => res.json())
+      .then(setCategories)
+  }
+
+  useEffect(() => {
+    fetchCategories()
+  }, [])
+
+  const handleDelete = async (id: string) => {
+    await fetch(`/api/categories/${id}`, { method: 'DELETE' })
+    fetchCategories()
+  }
+
+  return (
+    <div className="space-y-2">
+      {categories.map((c) => (
+        <div key={c.id} className="card flex items-center justify-between">
+          <span>{c.name}</span>
+          {c.expense_count === 0 && (
+            <button
+              onClick={() => handleDelete(c.id)}
+              className="px-2 py-1 text-sm bg-red-500 text-white rounded w-fit"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/(app)/categories/page.tsx
+++ b/app/(app)/categories/page.tsx
@@ -1,17 +1,17 @@
 import { serverClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
+import CategoriesList from './CategoriesList'
 
 export default async function CategoriesPage() {
   const supabase = serverClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
   if (!user) redirect('/login')
-  const { data } = await supabase.from('categories').select('*').order('created_at', { ascending: false })
   return (
     <main className="container py-6">
       <h1 className="text-xl font-semibold mb-4">Categories</h1>
-      <div className="space-y-2">
-        {(data ?? []).map((c:any)=> <div key={c.id} className="card">{c.name}</div>)}
-      </div>
+      <CategoriesList />
     </main>
   )
 }

--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -15,7 +15,21 @@ export async function DELETE(_req: Request, { params }: { params: { id: string }
   const supabase = serverClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return new NextResponse('Unauthorized', { status: 401 })
-  const { error } = await supabase.from('categories').delete().eq('id', params.id).eq('user_id', user.id)
+  const { count, error: countError } = await supabase
+    .from('expenses')
+    .select('id', { count: 'exact', head: true })
+    .eq('category_id', params.id)
+    .eq('user_id', user.id)
+  if (countError) return NextResponse.json({ error: countError.message }, { status: 400 })
+  if (count && count > 0) {
+    return NextResponse.json({ error: 'Category has expenses' }, { status: 400 })
+  }
+
+  const { error } = await supabase
+    .from('categories')
+    .delete()
+    .eq('id', params.id)
+    .eq('user_id', user.id)
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })
   return new NextResponse(null, { status: 204 })
 }

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -7,11 +7,17 @@ export async function GET() {
   if (!user) return new NextResponse('Unauthorized', { status: 401 })
   const { data, error } = await supabase
     .from('categories')
-    .select('*')
+    .select('id, name, created_at, expenses(count)')
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })
-  return NextResponse.json(data)
+  const mapped = (data ?? []).map((c: any) => ({
+    id: c.id,
+    name: c.name,
+    created_at: c.created_at,
+    expense_count: c.expenses?.[0]?.count ?? 0,
+  }))
+  return NextResponse.json(mapped)
 }
 
 export async function POST(req: Request) {

--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -57,6 +57,32 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     }
   }
 
+  let category_id: string | null = null
+  if (body.category && String(body.category).trim() !== '') {
+    const { data: existingCategory, error: categoryFetchError } = await supabase
+      .from('categories')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('name', body.category)
+      .maybeSingle()
+    if (categoryFetchError) {
+      return NextResponse.json({ error: categoryFetchError.message }, { status: 400 })
+    }
+    if (existingCategory) {
+      category_id = existingCategory.id
+    } else {
+      const { data: newCategory, error: categoryInsertError } = await supabase
+        .from('categories')
+        .insert({ name: body.category, user_id: user.id })
+        .select('id')
+        .single()
+      if (categoryInsertError) {
+        return NextResponse.json({ error: categoryInsertError.message }, { status: 400 })
+      }
+      category_id = newCategory.id
+    }
+  }
+
   let account_id: string | null = null
   if (body.account && String(body.account).trim() !== '') {
     const { data: existingAccount, error: accountFetchError } = await supabase
@@ -89,7 +115,9 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     date: dateObj.toISOString(),
     description: body.description,
     vendor: body.vendor,
+    category: body.category,
     vendor_id,
+    category_id,
     account_id,
   }
   const { data, error } = await supabase

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -99,7 +99,8 @@ CREATE TABLE IF NOT EXISTS public.categories (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
   name TEXT NOT NULL,
-  created_at TIMESTAMPTZ DEFAULT NOW()
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  CONSTRAINT unique_user_category UNIQUE (user_id, name)
 );
 
 ALTER TABLE public.categories ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- Add unique-per-user categories with delete protection when used by expenses
- Link expenses to categories and default new expenses to last used category
- Manage categories in UI with counts and conditional deletion

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c370adbd883308e8d8c1197575b05