### PR TITLE
feat: add receipt image upload to expense forms

### DIFF
--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -119,6 +119,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     vendor_id,
     category_id,
     account_id,
+    receipt_url: body.receipt_url,
   }
   const { data, error } = await supabase
     .from('expenses')

--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -129,6 +129,7 @@ export async function POST(req: Request) {
     vendor_id,
     category_id,
     account_id,
+    receipt_url: body.receipt_url,
   }
   const { data, error } = await supabase.from('expenses').insert(insert).select().single()
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })


### PR DESCRIPTION
## Summary
- add file input to expense create/edit pages for uploading receipt images
- upload receipt to Supabase storage and include `receipt_url` when saving
- update API routes to persist `receipt_url` and show existing receipt when editing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c3a7beed48330983e15561bb3beeb