### PR TITLE
Show existing receipt link when editing an expense

### DIFF
--- a/app/(app)/expenses/[id]/page.tsx
+++ b/app/(app)/expenses/[id]/page.tsx
@@ -84,13 +84,22 @@ export default function EditExpensePage({ params }: { params: { id: string } }) 
 
   useEffect(() => {
     const createSigned = async () => {
-      if (receiptUrl) {
-        const { data } = await supabase.storage
-          .from("receipts")
-          .createSignedUrl(receiptUrl, 60);
-        setSignedUrl(data?.signedUrl || null);
-      } else {
+      if (!receiptUrl) {
         setSignedUrl(null);
+        return;
+      }
+      try {
+        const res = await fetch("/api/receipts/sign-download", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ path: receiptUrl }),
+        });
+        if (res.ok) {
+          const { url } = await res.json();
+          setSignedUrl(url);
+        }
+      } catch (e) {
+        console.error("Failed to create signed URL", e);
       }
     };
     createSigned();


### PR DESCRIPTION
## Summary
- fetch signed download URL for existing receipt when editing an expense
- expose "View current receipt" link for uploaded images

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c3c8c5cf48330ba34700bb3ca8080