### PR TITLE
fix: create storage buckets for receipts and exports

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -167,6 +167,15 @@ USING (auth.uid() = user_id);
 -- Additional index for expenses export references
 CREATE INDEX IF NOT EXISTS expenses_export_id_idx ON public.expenses(export_id);
 
+-- Ensure buckets exist for storing receipts and exports
+INSERT INTO storage.buckets (id, name)
+VALUES ('receipts', 'receipts')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO storage.buckets (id, name)
+VALUES ('exports', 'exports')
+ON CONFLICT (id) DO NOTHING;
+
 -- Modify the storage policies to fix type casting issue
 DO $$
 BEGIN


### PR DESCRIPTION
## Summary
- ensure `receipts` and `exports` buckets exist during schema setup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c3ec70bdc8330ae5532c95b5ba009