### PR TITLE
Streamline dashboard and menu

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -15,30 +15,27 @@ export default async function DashboardPage() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/login')
 
-  const ym = new Date().toISOString().slice(0,7)
-  const start = ym + '-01'
-  const end = ym + '-31'
-  const { data: monthExpenses } = await supabase
+  const { data: expenses } = await supabase
     .from('expenses')
     .select('id, description, vendor, amount, currency, date')
     .eq('user_id', user.id)
-    .gte('date', start)
-    .lte('date', end)
+    .is('export_id', null)
     .order('date', { ascending: false })
 
-  const total = monthExpenses?.reduce((sum: number, e: any) => sum + e.amount, 0) ?? 0
-  const recent = monthExpenses?.slice(0,5) ?? []
+  const total = expenses?.reduce((sum: number, e: any) => sum + e.amount, 0) ?? 0
+  const count = expenses?.length ?? 0
+  const list = expenses ?? []
 
   return (
     <main className="container py-6">
       <UserHeader />
       <div className="grid gap-3">
         <div className="card">
-          <h2 className="font-semibold mb-2">Quick stats</h2>
-          <p className="text-sm text-neutral-600">Month: {ym}</p>
-          <p className="text-sm">Total: {total}</p>
+          <h2 className="font-semibold mb-2">Unclaimed Expenses</h2>
+          <p className="text-sm">Total value: {aud.format(total)}</p>
+          <p className="text-sm">Total expenses: {count}</p>
           <ul className="mt-2 divide-y">
-            {recent.map((e: any) => (
+            {list.map((e: any) => (
               <li key={e.id} className="grid grid-cols-4 items-center py-2 gap-2">
                 <Link className="underline" href={`/expenses/${e.id}`}>
                   {e.date?.slice(0, 10)}

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -2,11 +2,15 @@
 import { supabase } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
 
-export default function LogoutButton() {
+export default function LogoutButton({ className = 'px-3 py-2 rounded-md border' }: { className?: string }) {
   const router = useRouter()
   const onClick = async () => {
     await supabase.auth.signOut()
     router.push('/login')
   }
-  return <button onClick={onClick} className="px-3 py-2 rounded-md border">Log out</button>
+  return (
+    <button onClick={onClick} className={className}>
+      Log out
+    </button>
+  )
 }

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import LogoutButton from './LogoutButton'
 
 export default function Menu() {
   return (
@@ -15,6 +16,7 @@ export default function Menu() {
           </div>
         </details>
         <Link href="/settings" className="block px-4 py-2 hover:bg-neutral-100">Profile</Link>
+        <LogoutButton className="block w-full text-left px-4 py-2 hover:bg-neutral-100" />
       </div>
     </details>
   )

--- a/components/UserHeader.tsx
+++ b/components/UserHeader.tsx
@@ -1,5 +1,3 @@
-import LogoutButton from './LogoutButton'
-import Menu from './Menu'
 import { serverClient } from '@/lib/supabase/server'
 
 export default async function UserHeader() {
@@ -8,16 +6,10 @@ export default async function UserHeader() {
   const email = user?.email ?? ''
   const name = (user?.user_metadata as any)?.full_name || (user?.user_metadata as any)?.name || email
   return (
-    <div className="flex items-center justify-between mb-4">
-      <div>
-        <div className="text-sm text-neutral-500">Signed in as</div>
-        <div className="font-medium">{name}</div>
-        <div className="text-xs text-neutral-500">{email}</div>
-      </div>
-      <div className="flex items-center gap-2">
-        <Menu />
-        <LogoutButton />
-      </div>
+    <div className="mb-4">
+      <div className="text-sm text-neutral-500">Signed in as</div>
+      <div className="font-medium">{name}</div>
+      <div className="text-xs text-neutral-500">{email}</div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Show unclaimed expenses with totals and counts on the dashboard
- Simplify user header and integrate logout into the main menu
- Allow logout button to be styled when placed inside dropdown

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c46cc61a48330b94bd3f2628db129