### PR TITLE
feat: add table header to expenses list

### DIFF
--- a/app/(app)/expenses/page.tsx
+++ b/app/(app)/expenses/page.tsx
@@ -28,6 +28,12 @@ export default async function ExpensesPage() {
         <h1 className="text-xl font-semibold">Expenses</h1>
         <ExportsPane />
       </div>
+      <div className="grid grid-cols-4 gap-4 pb-2 font-medium text-sm">
+        <div>Date</div>
+        <div>Vendor</div>
+        <div>Description</div>
+        <div className="justify-self-end">Amount</div>
+      </div>
       <div className="divide-y">
         {(expenses ?? []).map((e: any) => (
           <div


### PR DESCRIPTION
## Summary
- show Date, Vendor, Description and Amount as headers above expense rows

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c4bdb9a188330a1d9057289f6d5ac