### PR TITLE
Remove labels from expense cards

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -39,14 +39,10 @@ export default async function DashboardPage() {
               <li key={e.id}>
                 <Link href={`/expenses/${e.id}`} className="card block">
                   <div className="grid grid-cols-2 gap-x-2 gap-y-1 text-sm">
-                    <span className="font-semibold">Date</span>
                     <span>{e.date?.slice(0, 10)}</span>
-                    <span className="font-semibold">Vendor</span>
-                    <span>{e.vendor || '—'}</span>
-                    <span className="font-semibold">Description</span>
-                    <span>{e.description || '—'}</span>
-                    <span className="font-semibold">Amount</span>
                     <span className="justify-self-end">{aud.format(e.amount)}</span>
+                    <span className="col-span-2">{e.vendor || '—'}</span>
+                    <span className="col-span-2">{e.description || '—'}</span>
                   </div>
                 </Link>
               </li>


### PR DESCRIPTION
## Summary
- remove static field labels from dashboard expense cards and present values directly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: useSearchParams() should be wrapped in a suspense boundary at page "/login". Export encountered errors on following paths: /(auth)/login/page: /login)*

------
https://chatgpt.com/codex/tasks/task_e_689c4d96bffc8330a24851bbd033c210