### PR TITLE
fix receipt extraction image payload

### DIFF
--- a/app/api/receipts/extract/route.ts
+++ b/app/api/receipts/extract/route.ts
@@ -25,14 +25,21 @@ export async function POST(req: NextRequest) {
           {
             role: "user",
             content: [
-              { type: "input_text", text: "Here is the receipt:" },
-              { type: "input_image", image_url: `data:image/jpeg;base64,${image}` },
+              { type: "text", text: "Here is the receipt:" },
+              {
+                type: "image_url",
+                image_url: { url: `data:image/jpeg;base64,${image}` },
+              },
             ],
           },
         ],
         response_format: { type: "json_object" },
       }),
     });
+    if (!res.ok) {
+      const errorText = await res.text();
+      throw new Error(`OpenAI API error: ${res.status} ${errorText}`);
+    }
     const data = await res.json();
     const message = data.choices?.[0]?.message?.content;
     if (!message) throw new Error("No response from model");


### PR DESCRIPTION
## Summary
- use OpenAI chat `text` and `image_url` parts for receipt extraction
- guard against OpenAI API failures

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c52f8134c83308dbc60ea54297c3c