### PR TITLE
Add expense export flow with email attachments

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -54,6 +54,12 @@ export default async function DashboardPage() {
           >
             Add expense
           </Link>
+          <Link
+            href="/exports/new"
+            className="bg-black text-white py-2 rounded-md block text-center mt-2"
+          >
+            Export expenses
+          </Link>
         </div>
       </div>
     </main>

--- a/app/(app)/exports/new/ExportExpenses.tsx
+++ b/app/(app)/exports/new/ExportExpenses.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function ExportExpenses({ initialExpenses, userEmail }:{ initialExpenses: any[], userEmail: string }) {
+  const [selected, setSelected] = useState<string[]>(initialExpenses.map(e=> e.id))
+  const [email, setEmail] = useState<string>(userEmail)
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+
+  const toggle = (id: string) => {
+    setSelected(prev => prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id])
+  }
+
+  const submit = async () => {
+    setLoading(true)
+    const res = await fetch('/api/exports/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: selected, email })
+    })
+    setLoading(false)
+    if (res.ok) {
+      router.push('/dashboard')
+      router.refresh()
+    } else {
+      console.error('Failed to export expenses', await res.text())
+    }
+  }
+
+  return (
+    <main className="container py-6">
+      <h1 className="text-xl font-semibold mb-4">Export expenses</h1>
+      <div className="card space-y-4">
+        <input type="email" placeholder="Email" value={email} onChange={e=> setEmail(e.target.value)} />
+        <div className="max-h-64 overflow-y-auto divide-y">
+          {initialExpenses.map(e => (
+            <label key={e.id} className="flex items-center gap-2 py-2 text-sm">
+              <input type="checkbox" checked={selected.includes(e.id)} onChange={()=> toggle(e.id)} />
+              <span className="flex-1">{e.date?.slice(0,10)} — {e.vendor || '—'} — {e.description || '—'} — {e.amount} {e.currency}</span>
+            </label>
+          ))}
+          {!initialExpenses.length && <p className="text-sm text-neutral-600">No expenses available</p>}
+        </div>
+        <button disabled={!selected.length || loading} onClick={submit} className="bg-black text-white py-2 rounded-md">
+          {loading ? 'Exporting…' : 'Confirm export'}
+        </button>
+      </div>
+    </main>
+  )
+}

--- a/app/(app)/exports/new/page.tsx
+++ b/app/(app)/exports/new/page.tsx
@@ -1,0 +1,20 @@
+import ExportExpenses from './ExportExpenses'
+import { serverClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+
+export const revalidate = 0
+
+export default async function NewExportPage() {
+  const supabase = serverClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: expenses } = await supabase
+    .from('expenses')
+    .select('id, amount, currency, date, description, vendor')
+    .eq('user_id', user.id)
+    .is('export_id', null)
+    .order('date', { ascending: false })
+
+  return <ExportExpenses initialExpenses={expenses ?? []} userEmail={user.email ?? ''} />
+}

--- a/app/api/exports/create/route.ts
+++ b/app/api/exports/create/route.ts
@@ -3,6 +3,7 @@ import { serverClient } from '@/lib/supabase/server'
 import JSZip from 'jszip'
 import { buildExpenseFormPdf } from '@/lib/pdf'
 import { toCsv } from '@/lib/csv'
+import nodemailer from 'nodemailer'
 
 function sanitize(name: string) {
   return name.replace(/[^a-zA-Z0-9._-]/g, '_')
@@ -13,18 +14,39 @@ export async function POST(req: Request) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return new NextResponse('Unauthorized', { status: 401 })
 
-  const { month, includeExported = false, currency } = await req.json()
-  if (!month) return NextResponse.json({ error: 'month is required YYYY-MM' }, { status: 400 })
-  const start = month + '-01'
-  const end = month + '-31'
+  const { month, includeExported = false, currency, ids = [], email } = await req.json()
 
-  let q = supabase.from('expenses')
-    .select('id, amount, currency, date, description, vendor, category, receipt_url, export_id')
-    .eq('user_id', user.id)
-    .gte('date', start).lte('date', end)
-  if (!includeExported) q = q.is('export_id', null)
-  const { data: expenses, error } = await q
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  let expenses: any[] | null = null
+  let start = ''
+  let end = ''
+  let periodLabel = ''
+
+  if (ids && ids.length) {
+    const { data, error } = await supabase
+      .from('expenses')
+      .select('id, amount, currency, date, description, vendor, category, receipt_url, export_id')
+      .eq('user_id', user.id)
+      .in('id', ids)
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    expenses = data || []
+    const dates = expenses.map(e => e.date).sort()
+    start = dates[0] || ''
+    end = dates[dates.length - 1] || ''
+    periodLabel = start && end ? `${start.slice(0,10)}→${end.slice(0,10)}` : 'custom'
+  } else {
+    if (!month) return NextResponse.json({ error: 'month is required YYYY-MM' }, { status: 400 })
+    start = month + '-01'
+    end = month + '-31'
+    let q = supabase.from('expenses')
+      .select('id, amount, currency, date, description, vendor, category, receipt_url, export_id')
+      .eq('user_id', user.id)
+      .gte('date', start).lte('date', end)
+    if (!includeExported) q = q.is('export_id', null)
+    const { data, error } = await q
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    expenses = data || []
+    periodLabel = month
+  }
 
   const total = (expenses || []).reduce((s, e:any)=> s + Number(e.amount || 0), 0)
   const chosenCurrency = (currency || process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || 'AUD').toUpperCase()
@@ -33,15 +55,11 @@ export async function POST(req: Request) {
   const pdfBytes = await buildExpenseFormPdf({
     appName: process.env.NEXT_PUBLIC_APP_NAME || 'SpendWise',
     userEmail: user.email || '',
-    periodLabel: month,
+    periodLabel,
     totals: { total, currency: chosenCurrency, count: expenses?.length || 0 }
   })
 
-  const zip = new JSZip()
-  const folder = zip.folder(`export`)!
-  folder.file(`expenses-${month}.csv`, csv)
-  folder.file(`expense-form.pdf`, pdfBytes)
-  const receiptsFolder = folder.folder('receipts')!
+  const receiptsZip = new JSZip()
 
   for (const e of expenses || []) {
     if (e.receipt_url) {
@@ -49,19 +67,26 @@ export async function POST(req: Request) {
       if (file) {
         const parts = e.receipt_url.split('/')
         const filename = parts[parts.length-1]
-        receiptsFolder.file(`${e.id}-${sanitize(filename)}`, Buffer.from(await file.arrayBuffer()))
+        receiptsZip.file(`${e.id}-${sanitize(filename)}`, Buffer.from(await file.arrayBuffer()))
       }
     }
   }
 
+  const receiptsZipBytes = await receiptsZip.generateAsync({ type: 'uint8array' })
+
+  const zip = new JSZip()
+  const folder = zip.folder(`export`)!
+  folder.file(`expenses.csv`, csv)
+  folder.file(`expense-form.pdf`, pdfBytes)
+  folder.file('receipts.zip', receiptsZipBytes)
   const zipBytes = await zip.generateAsync({ type: 'uint8array' })
-  const filePath = `exports/${user.id}/${month}/export-${Date.now()}.zip`
+  const filePath = `exports/${user.id}/${Date.now()}.zip`
   await supabase.storage.from('exports').upload(filePath, zipBytes, { contentType: 'application/zip', upsert: true })
 
   const { data: created, error: e2 } = await supabase.from('exports').insert({
     user_id: user.id,
-    period_start: start,
-    period_end: end,
+    period_start: start || null,
+    period_end: end || null,
     file_path: filePath,
     total_amount: total,
     currency: chosenCurrency,
@@ -72,6 +97,30 @@ export async function POST(req: Request) {
   // mark expenses exported
   if (expenses && expenses.length) {
     await supabase.from('expenses').update({ export_id: created.id }).in('id', expenses.map((e:any)=> e.id))
+  }
+
+  if (email) {
+    try {
+      const transporter = nodemailer.createTransport({
+        host: process.env.SMTP_HOST,
+        port: Number(process.env.SMTP_PORT || 587),
+        secure: false,
+        auth: process.env.SMTP_USER ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS } : undefined,
+      })
+      await transporter.sendMail({
+        from: process.env.SMTP_FROM || process.env.SMTP_USER,
+        to: email,
+        subject: 'Expense export',
+        text: 'Please find attached your exported expenses.',
+        attachments: [
+          { filename: 'expense-form.pdf', content: Buffer.from(pdfBytes) },
+          { filename: 'expenses.csv', content: csv },
+          { filename: 'receipts.zip', content: Buffer.from(receiptsZipBytes), contentType: 'application/zip' }
+        ]
+      })
+    } catch (err) {
+      console.error('Failed to send export email', err)
+    }
   }
 
   const { data: urlData } = await supabase.storage.from('exports').createSignedUrl(filePath, 60)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "date-fns": "^3.6.0",
         "jszip": "^3.10.1",
         "next": "14.2.5",
+        "nodemailer": "^6.10.1",
         "pdf-lib": "^1.17.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -21,6 +22,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.12.7",
+        "@types/nodemailer": "^6.4.17",
         "@types/react": "^18.2.66",
         "autoprefixer": "^10.4.19",
         "eslint": "^8.57.0",
@@ -673,6 +675,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/phoenix": {
@@ -4206,6 +4218,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "date-fns": "^3.6.0",
     "jszip": "^3.10.1",
     "next": "14.2.5",
+    "nodemailer": "^6.10.1",
     "pdf-lib": "^1.17.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
+    "@types/nodemailer": "^6.4.17",
     "@types/react": "^18.2.66",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",


### PR DESCRIPTION
## Summary
- add export expenses button on dashboard
- allow selecting expenses and destination email before exporting
- extend export API to build PDF/CSV, zip receipts, mark expenses exported, and email attachments

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c575b2c808330983eae591be81b73