### PR TITLE
Simplify export confirmation details

### DIFF
--- a/app/(app)/exports/new/ExportExpenses.tsx
+++ b/app/(app)/exports/new/ExportExpenses.tsx
@@ -37,8 +37,8 @@ export default function ExportExpenses({ initialExpenses, userEmail }:{ initialE
         <div className="max-h-64 overflow-y-auto divide-y">
           {initialExpenses.map(e => (
             <label key={e.id} className="flex items-center gap-2 py-2 text-sm">
-              <input type="checkbox" checked={selected.includes(e.id)} onChange={()=> toggle(e.id)} />
-              <span className="flex-1">{e.date?.slice(0,10)} — {e.vendor || '—'} — {e.description || '—'} — {e.amount} {e.currency}</span>
+              <input type="checkbox" checked={selected.includes(e.id)} onChange={() => toggle(e.id)} />
+              <span className="flex-1">{e.vendor || '—'} — {e.category || '—'} — {e.amount} {e.currency}</span>
             </label>
           ))}
           {!initialExpenses.length && <p className="text-sm text-neutral-600">No expenses available</p>}

--- a/app/(app)/exports/new/page.tsx
+++ b/app/(app)/exports/new/page.tsx
@@ -11,7 +11,7 @@ export default async function NewExportPage() {
 
   const { data: expenses } = await supabase
     .from('expenses')
-    .select('id, amount, currency, date, description, vendor')
+    .select('id, amount, currency, date, vendor, category')
     .eq('user_id', user.id)
     .is('export_id', null)
     .order('date', { ascending: false })


### PR DESCRIPTION
## Summary
- Show only vendor, category, and amount for each expense during export confirmation
- Include category field when loading exportable expenses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c71cf6e308330bf32912714de7bdb