### PR TITLE
fix: replace unsupported characters in export pdf

### DIFF
--- a/app/api/exports/create/route.ts
+++ b/app/api/exports/create/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: Request) {
       const dates = expenses.map(e => e.date).sort()
       start = dates[0] || ''
       end = dates[dates.length - 1] || ''
-      periodLabel = start && end ? `${start.slice(0,10)}→${end.slice(0,10)}` : 'custom'
+      periodLabel = start && end ? `${start.slice(0,10)} to ${end.slice(0,10)}` : 'custom'
     } else {
       if (!month) return NextResponse.json({ error: 'month is required YYYY-MM' }, { status: 400 })
       start = month + '-01'

--- a/lib/pdf.ts
+++ b/lib/pdf.ts
@@ -10,11 +10,13 @@ export async function buildExpenseFormPdf(opts: {
   const page = doc.addPage([612, 792]) // US Letter
   const font = await doc.embedFont(StandardFonts.Helvetica)
 
+  const sanitize = (text: string) => text.replace(/→/g, '->').replace(/[\x80-\uFFFF]/g, '')
+
   const draw = (text: string, x: number, y: number, size=12) => {
-    page.drawText(text, { x, y, size, font, color: rgb(0,0,0) })
+    page.drawText(sanitize(text), { x, y, size, font, color: rgb(0,0,0) })
   }
 
-  draw(opts.appName + ' — Expense Report', 50, 740, 18)
+  draw(opts.appName + ' - Expense Report', 50, 740, 18)
   draw('User: ' + opts.userEmail, 50, 710, 12)
   draw('Period: ' + opts.periodLabel, 50, 690, 12)
   draw(`Total: ${opts.totals.total.toFixed(2)} ${opts.totals.currency} (${opts.totals.count} items)`, 50, 670, 12)


### PR DESCRIPTION
## Summary
- prevent pdf generation from failing on unsupported characters
- remove arrow from period label in export route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c75448a24833082f8adcddbe4debf