### PR TITLE
Wrap login page in suspense boundary

### DIFF
--- a/app/(auth)/login/LoginForm.tsx
+++ b/app/(auth)/login/LoginForm.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { supabase } from "@/lib/supabase/client";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export default function LoginForm() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [fullName, setFullName] = useState("");
+  const [mode, setMode] = useState<"signin" | "signup">("signin");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+  const params = useSearchParams();
+  const redirectTo = params.get("redirect") || "/dashboard";
+
+  const onEmailPassword = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      if (mode === "signup") {
+        const { error } = await supabase.auth.signUp({
+          email,
+          password,
+          options: { data: { full_name: fullName } },
+        });
+        if (error) throw error;
+      } else {
+        const { error } = await supabase.auth.signInWithPassword({ email, password });
+        if (error) throw error;
+      }
+      router.push(redirectTo);
+    } catch (e: any) {
+      setError(e.message || "Auth error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onGithub = async () => {
+    await supabase.auth.signInWithOAuth({
+      provider: "github",
+      options: { redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback` },
+    });
+  };
+
+  return (
+    <main className="container py-10">
+      <div className="max-w-md mx-auto card">
+        <h1 className="text-2xl font-semibold mb-4">Welcome</h1>
+        <div className="space-y-3">
+          {mode === "signup" && (
+            <input
+              placeholder="Full name"
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+            />
+          )}
+          <input
+            placeholder="Email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <input
+            placeholder="Password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button
+            onClick={onEmailPassword}
+            disabled={loading}
+            className="bg-black text-white py-2 rounded-md"
+          >
+            {loading ? "Please wait…" : mode === "signup" ? "Sign up" : "Sign in"}
+          </button>
+          <button onClick={onGithub} className="py-2 rounded-md border">
+            Continue with GitHub
+          </button>
+          <p className="text-sm">
+            {mode === "signup" ? "Already have an account?" : "New here?"}{" "}
+            <button
+              onClick={() => setMode(mode === "signup" ? "signin" : "signup")}
+              className="underline"
+            >
+              {mode === "signup" ? "Sign in" : "Create an account"}
+            </button>
+          </p>
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,71 +1,10 @@
-'use client'
-
-import { useState } from 'react'
-import { supabase } from '@/lib/supabase/client'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { Suspense } from "react";
+import LoginForm from "./LoginForm";
 
 export default function LoginPage() {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [fullName, setFullName] = useState('')
-  const [mode, setMode] = useState<'signin'|'signup'>('signin')
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const router = useRouter()
-  const params = useSearchParams()
-  const redirectTo = params.get('redirect') || '/dashboard'
-
-  const onEmailPassword = async () => {
-    try {
-      setLoading(true); setError(null)
-      if (mode === 'signup') {
-        const { error } = await supabase.auth.signUp({
-          email, password,
-          options: { data: { full_name: fullName } }
-        })
-        if (error) throw error
-      } else {
-        const { error } = await supabase.auth.signInWithPassword({ email, password })
-        if (error) throw error
-      }
-      router.push(redirectTo)
-    } catch (e: any) {
-      setError(e.message || 'Auth error')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const onGithub = async () => {
-    await supabase.auth.signInWithOAuth({
-      provider: 'github',
-      options: { redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback` }
-    })
-  }
-
   return (
-    <main className="container py-10">
-      <div className="max-w-md mx-auto card">
-        <h1 className="text-2xl font-semibold mb-4">Welcome</h1>
-        <div className="space-y-3">
-          {mode === 'signup' && (
-            <input placeholder="Full name" value={fullName} onChange={(e)=>setFullName(e.target.value)} />
-          )}
-          <input placeholder="Email" type="email" value={email} onChange={(e)=>setEmail(e.target.value)} />
-          <input placeholder="Password" type="password" value={password} onChange={(e)=>setPassword(e.target.value)} />
-          <button onClick={onEmailPassword} disabled={loading} className="bg-black text-white py-2 rounded-md">
-            {loading ? 'Please wait…' : (mode === 'signup' ? 'Sign up' : 'Sign in')}
-          </button>
-          <button onClick={onGithub} className="py-2 rounded-md border">Continue with GitHub</button>
-          <p className="text-sm">
-            {mode === 'signup' ? 'Already have an account?' : 'New here?'}{' '}
-            <button onClick={()=>setMode(mode==='signup'?'signin':'signup')} className="underline">
-              {mode === 'signup' ? 'Sign in' : 'Create an account'}
-            </button>
-          </p>
-          {error && <p className="text-red-600 text-sm">{error}</p>}
-        </div>
-      </div>
-    </main>
-  )
+    <Suspense fallback={<div>Loading...</div>}>
+      <LoginForm />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- Split login page into client LoginForm and server wrapper
- Wrap login form in React Suspense to satisfy `useSearchParams` requirements

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c7eafeafc8330aae656b1d102d7a9