### PR TITLE
Handle receipt extraction with multipart form data

### DIFF
--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -19,23 +19,13 @@ export default function NewExpensePage() {
 
   const extract = async () => {
     if (!receiptFile) return;
-    const toBase64 = (file: File) =>
-      new Promise<string>((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => {
-          const result = reader.result as string;
-          resolve(result.split(",")[1]);
-        };
-        reader.onerror = reject;
-        reader.readAsDataURL(file);
-      });
 
     try {
-      const base64 = await toBase64(receiptFile);
+      const formData = new FormData();
+      formData.append("image", receiptFile);
       const res = await fetch("/api/receipts/extract", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ image: base64 }),
+        body: formData,
       });
       if (!res.ok) return;
       const data = await res.json();


### PR DESCRIPTION
## Summary
- support multipart form uploads in receipt extraction endpoint
- improve missing-data checks for clearer errors
- adjust new expense page to send files via FormData

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c839f1e848330ba034926b77b7496