### PR TITLE
Reset date after receipt extraction

### DIFF
--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -31,7 +31,12 @@ export default function NewExpensePage() {
       const data = await res.json();
       if (data.amount) setAmount(data.amount.toString());
       if (data.currency) setCurrency(data.currency.toUpperCase());
-      if (data.date) setDate(data.date.slice(0, 10));
+      if (data.date) {
+        setDate(data.date.slice(0, 10));
+      } else {
+        // reset to today's date if none found on the receipt
+        setDate(new Date().toISOString().slice(0, 10));
+      }
       if (data.description) setDescription(data.description);
       if (data.vendor) setVendor(data.vendor);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Reset date picker to receipt date or today when extracting receipt details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c8f4cd9fc8330ba3f327b5844f109