### PR TITLE
Handle day-first dates in expenses

### DIFF
--- a/app/(app)/expenses/[id]/page.tsx
+++ b/app/(app)/expenses/[id]/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
+import { parseDateInput } from "@/lib/date";
 
 export default function EditExpensePage({ params }: { params: { id: string } }) {
   const { id } = params;
@@ -112,7 +113,7 @@ export default function EditExpensePage({ params }: { params: { id: string } }) 
     if (!user) return;
 
     const parsedAmount = parseFloat(amount);
-   const parsedDate = new Date(date);
+    const parsedDate = parseDateInput(date) ?? new Date();
     let newReceiptUrl = receiptUrl;
     if (receiptFile) {
       const fileExt = receiptFile.name.split(".").pop() || "jpg";

--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
+import { parseDateInput } from "@/lib/date";
 
 export default function NewExpensePage() {
   const [amount, setAmount] = useState("");
@@ -32,7 +33,10 @@ export default function NewExpensePage() {
       if (data.amount) setAmount(data.amount.toString());
       if (data.currency) setCurrency(data.currency.toUpperCase());
       if (data.date) {
-        setDate(data.date.slice(0, 10));
+        const parsed = parseDateInput(data.date);
+        setDate(
+          parsed ? parsed.toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10)
+        );
       } else {
         // reset to today's date if none found on the receipt
         setDate(new Date().toISOString().slice(0, 10));
@@ -89,7 +93,7 @@ export default function NewExpensePage() {
     if (!user) return;
 
     const parsedAmount = parseFloat(amount);
-    const parsedDate = new Date(date);
+    const parsedDate = parseDateInput(date) ?? new Date();
     let receipt_url: string | null = null;
     if (receiptFile) {
       const fileExt = receiptFile.name.split(".").pop() || "jpg";

--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { serverClient } from '@/lib/supabase/server'
+import { parseDateInput } from '@/lib/date'
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
   const supabase = serverClient()
@@ -26,8 +27,8 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     return NextResponse.json({ error: 'Invalid amount' }, { status: 400 })
   }
 
-  const dateObj = new Date(body.date)
-  if (isNaN(dateObj.getTime())) {
+  const dateObj = parseDateInput(body.date)
+  if (!dateObj || isNaN(dateObj.getTime())) {
     return NextResponse.json({ error: 'Invalid date' }, { status: 400 })
   }
 

--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { serverClient } from '@/lib/supabase/server'
+import { parseDateInput } from '@/lib/date'
 
 export async function GET(req: Request) {
   const supabase = serverClient()
@@ -35,8 +36,8 @@ export async function POST(req: Request) {
   }
 
   // validate and normalise date
-  const dateObj = new Date(body.date)
-  if (isNaN(dateObj.getTime())) {
+  const dateObj = parseDateInput(body.date)
+  if (!dateObj || isNaN(dateObj.getTime())) {
     return NextResponse.json({ error: 'Invalid date' }, { status: 400 })
   }
 

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,15 @@
+import { parse, isValid } from "date-fns";
+
+/**
+ * Parse a date string in various formats into a Date object.
+ * Supports ISO strings (YYYY-MM-DD) and day-first formats like DD/MM/YYYY.
+ * Returns null if the input cannot be parsed.
+ */
+export function parseDateInput(value: string): Date | null {
+  if (!value) return null;
+  const iso = new Date(value);
+  if (!isNaN(iso.getTime())) return iso;
+  const dmy = parse(value, "d/M/yyyy", new Date());
+  if (isValid(dmy)) return dmy;
+  return null;
+}


### PR DESCRIPTION
## Summary
- parse day-first date strings from receipts and manual input
- normalize dates before saving expenses
- validate flexible date formats on the API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c934e17d08330b06b79ea17353d4c