### PR TITLE
Fix receipt date parsing

### DIFF
--- a/lib/date.ts
+++ b/lib/date.ts
@@ -7,9 +7,31 @@ import { parse, isValid } from "date-fns";
  */
 export function parseDateInput(value: string): Date | null {
   if (!value) return null;
+
   const iso = new Date(value);
-  if (!isNaN(iso.getTime())) return iso;
-  const dmy = parse(value, "d/M/yyyy", new Date());
-  if (isValid(dmy)) return dmy;
+  if (!isNaN(iso.getTime())) {
+    if (iso.getFullYear() < 100) {
+      iso.setFullYear(2000 + iso.getFullYear());
+    }
+    return iso;
+  }
+
+  const formats = [
+    "d/M/yyyy",
+    "d/M/yy",
+    "d MMM yyyy",
+    "d MMM yy",
+  ];
+
+  for (const f of formats) {
+    const parsed = parse(value, f, new Date());
+    if (isValid(parsed)) {
+      if (f.includes("yy") && !f.includes("yyyy") && parsed.getFullYear() < 100) {
+        parsed.setFullYear(2000 + parsed.getFullYear());
+      }
+      return parsed;
+    }
+  }
+
   return null;
 }


### PR DESCRIPTION
## Summary
- expand date parsing to handle month names and 2-digit years
- normalize parsed years under 100 into 2000s

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c963d3b0c8330ab84eeca04e84e58