### PR TITLE
Double-check receipt OCR results

### DIFF
--- a/app/api/receipts/extract/route.ts
+++ b/app/api/receipts/extract/route.ts
@@ -23,6 +23,7 @@ export async function POST(req: NextRequest) {
   const mimeType = file.type || "image/jpeg";
 
   try {
+    // First call: extract fields from the receipt image
     const res = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: {
@@ -58,7 +59,45 @@ export async function POST(req: NextRequest) {
     const data = await res.json();
     const message = data.choices?.[0]?.message?.content;
     if (!message) throw new Error("No response from model");
-    return NextResponse.json(JSON.parse(message));
+    const extracted = JSON.parse(message);
+
+    // Second call: verify the extracted fields against the receipt image
+    const verify = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are verifying extracted receipt data. Compare the provided fields with the image and correct any mistakes. Respond in JSON.",
+          },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: JSON.stringify(extracted) },
+              {
+                type: "image_url",
+                image_url: { url: `data:${mimeType};base64,${base64}` },
+              },
+            ],
+          },
+        ],
+        response_format: { type: "json_object" },
+      }),
+    });
+    if (!verify.ok) {
+      const errorText = await verify.text();
+      throw new Error(`OpenAI verify error: ${verify.status} ${errorText}`);
+    }
+    const verifyData = await verify.json();
+    const verifyMsg = verifyData.choices?.[0]?.message?.content;
+    if (!verifyMsg) throw new Error("No verification response from model");
+    return NextResponse.json(JSON.parse(verifyMsg));
   } catch (err) {
     console.error(err);
     return NextResponse.json({ error: "Failed to extract receipt" }, { status: 500 });


### PR DESCRIPTION
## Summary
- verify OpenAI receipt extraction by cross-checking output against the image

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c99b57c0c8330900d5d20a63616e8