### PR TITLE
feat: allow selecting existing receipt photos

### DIFF
--- a/app/(app)/expenses/[id]/page.tsx
+++ b/app/(app)/expenses/[id]/page.tsx
@@ -243,7 +243,6 @@ export default function EditExpensePage({ params }: { params: { id: string } }) 
         <input
           type="file"
           accept="image/*"
-          capture="environment"
           onChange={(e) => setReceiptFile(e.target.files?.[0] || null)}
         />
         <div className="flex gap-2">

--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -143,7 +143,6 @@ export default function NewExpensePage() {
           <input
             type="file"
             accept="image/*"
-            capture="environment"
             onChange={(e) => setReceiptFile(e.target.files?.[0] || null)}
           />
           {receiptFile && (


### PR DESCRIPTION
## Summary
- let users pick existing receipt images by removing camera-only capture attribute from upload fields

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c9b6b5b388330b138d406e91f8fcf