### PR TITLE
style: apply new button styling

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -50,13 +50,13 @@ export default async function DashboardPage() {
           </ul>
           <Link
             href="/expenses/new"
-            className="bg-black text-white py-2 rounded-md block text-center mt-2"
+            className="px-3 py-2 rounded-md border block text-center mt-2 hover:bg-neutral-100"
           >
             Add expense
           </Link>
           <Link
             href="/exports/new"
-            className="bg-black text-white py-2 rounded-md block text-center mt-2"
+            className="px-3 py-2 rounded-md border block text-center mt-2 hover:bg-neutral-100"
           >
             Export expenses
           </Link>

--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -302,7 +302,7 @@ export default function NewExpensePage() {
         <button
           onClick={submit}
           disabled={saving}
-          className="bg-black text-white py-2 rounded-md disabled:opacity-50"
+          className="px-3 py-2 rounded-md border disabled:opacity-50 hover:bg-neutral-100"
         >
           {saving ? "Saving..." : "Save"}
         </button>

--- a/app/(app)/exports/new/ExportExpenses.tsx
+++ b/app/(app)/exports/new/ExportExpenses.tsx
@@ -43,7 +43,11 @@ export default function ExportExpenses({ initialExpenses, userEmail }:{ initialE
           ))}
           {!initialExpenses.length && <p className="text-sm text-neutral-600">No expenses available</p>}
         </div>
-        <button disabled={!selected.length || loading} onClick={submit} className="bg-black text-white py-2 rounded-md">
+        <button
+          disabled={!selected.length || loading}
+          onClick={submit}
+          className="px-3 py-2 rounded-md border hover:bg-neutral-100"
+        >
           {loading ? 'Exporting…' : 'Confirm export'}
         </button>
       </div>


### PR DESCRIPTION
## Summary
- restyle add expense and export links on dashboard
- update add expense form to use new button styling
- apply new styling to export confirmation button

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d849eb968833083897f2c26e38928