### PR TITLE
Add sliding burger menu

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,9 +16,12 @@ export default async function Header() {
   return (
     <header className="border-b sb-2 mb-6">
       <div className="container flex items-center justify-between py-4">
-        <Link href="/dashboard" className="font-semibold">
-          SpendWise
-        </Link>
+        <div className="flex items-center gap-4">
+          <Menu />
+          <Link href="/dashboard" className="font-semibold">
+            SpendWise
+          </Link>
+        </div>
         <div className="flex items-center gap-3">
           {user && (
             <div className="flex items-center gap-2 sb-2">
@@ -28,7 +31,6 @@ export default async function Header() {
               <span className="text-sm hidden sm:inline">{name}</span>
             </div>
           )}
-          <Menu />
         </div>
       </div>
     </header>

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -1,23 +1,85 @@
+"use client"
+
+import { useState } from 'react'
 import Link from 'next/link'
 import LogoutButton from './LogoutButton'
 
 export default function Menu() {
+  const [open, setOpen] = useState(false)
+
   return (
-    <details className="relative">
-      <summary className="px-3 py-2 rounded-md border cursor-pointer select-none">Menu</summary>
-      <div className="absolute right-0 mt-2 w-48 bg-white border rounded-md shadow-md z-10">
-        <Link href="/expenses" className="block px-4 py-2 hover:bg-neutral-100">Expenses</Link>
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        aria-label="Open menu"
+        className="p-2"
+      >
+        <span className="block w-6 h-0.5 bg-current mb-1"></span>
+        <span className="block w-6 h-0.5 bg-current mb-1"></span>
+        <span className="block w-6 h-0.5 bg-current"></span>
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40"
+          onClick={() => setOpen(false)}
+        />
+      )}
+      <nav
+        className={`fixed top-0 left-0 h-full w-64 bg-white sb-2 z-50 transform transition-transform ${
+          open ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="p-4 flex justify-end">
+          <button onClick={() => setOpen(false)} aria-label="Close menu">
+            ✕
+          </button>
+        </div>
+        <Link
+          href="/expenses"
+          className="block px-4 py-2 hover:bg-neutral-100"
+          onClick={() => setOpen(false)}
+        >
+          Expenses
+        </Link>
         <details>
-          <summary className="px-4 py-2 hover:bg-neutral-100 cursor-pointer">Entities</summary>
+          <summary className="px-4 py-2 hover:bg-neutral-100 cursor-pointer">
+            Entities
+          </summary>
           <div>
-            <Link href="/accounts" className="block px-8 py-2 hover:bg-neutral-100">Accounts</Link>
-            <Link href="/categories" className="block px-8 py-2 hover:bg-neutral-100">Categories</Link>
-            <Link href="/vendors" className="block px-8 py-2 hover:bg-neutral-100">Vendors</Link>
+            <Link
+              href="/accounts"
+              className="block px-8 py-2 hover:bg-neutral-100"
+              onClick={() => setOpen(false)}
+            >
+              Accounts
+            </Link>
+            <Link
+              href="/categories"
+              className="block px-8 py-2 hover:bg-neutral-100"
+              onClick={() => setOpen(false)}
+            >
+              Categories
+            </Link>
+            <Link
+              href="/vendors"
+              className="block px-8 py-2 hover:bg-neutral-100"
+              onClick={() => setOpen(false)}
+            >
+              Vendors
+            </Link>
           </div>
         </details>
-        <Link href="/settings" className="block px-4 py-2 hover:bg-neutral-100">Profile</Link>
-        <LogoutButton className="block w-full text-left px-4 py-2 hover:bg-neutral-100" />
-      </div>
-    </details>
+        <Link
+          href="/settings"
+          className="block px-4 py-2 hover:bg-neutral-100"
+          onClick={() => setOpen(false)}
+        >
+          Profile
+        </Link>
+        <LogoutButton
+          className="block w-full text-left px-4 py-2 hover:bg-neutral-100"
+        />
+      </nav>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- replace dropdown menu with a sliding sidebar triggered by a burger button
- move menu launcher to the top-left of the header

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d8d46835c8330af4cc5b532dcd9d9