### PR TITLE
feat: add snap expense workflow

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -16,7 +16,7 @@ export default async function DashboardPage() {
 
   const { data: expenses } = await supabase
     .from('expenses')
-    .select('id, description, vendor, amount, currency, date')
+    .select('id, description, vendor, amount, currency, date, pending')
     .eq('user_id', user.id)
     .is('export_id', null)
     .order('date', { ascending: false })
@@ -34,6 +34,12 @@ export default async function DashboardPage() {
         >
           Add expense
         </Link>
+        <Link
+          href="/expenses/snap"
+          className="px-3 py-2 rounded-md border block text-center bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Snap expense
+        </Link>
         <div className="card">
           <h2 className="font-semibold mb-2">Unclaimed Expenses</h2>
           <p className="text-sm">Total value: {aud.format(total)}</p>
@@ -41,7 +47,7 @@ export default async function DashboardPage() {
           <ul className="mt-2 grid gap-3">
             {list.map((e: any) => (
               <li key={e.id}>
-                <Link href={`/expenses/${e.id}`} className="card block">
+                <Link href={`/expenses/${e.id}`} className={`card block ${e.pending ? 'bg-orange-100' : ''}`}>
                   <div className="grid grid-cols-2 gap-x-2 gap-y-1 text-sm">
                     <span>{e.date?.slice(0, 10)}</span>
                     <span className="justify-self-end">{aud.format(e.amount)}</span>

--- a/app/(app)/expenses/[id]/page.tsx
+++ b/app/(app)/expenses/[id]/page.tsx
@@ -226,6 +226,7 @@ export default function EditExpensePage({ params }: { params: { id: string } }) 
           category,
           account,
           receipt_url: newReceiptUrl,
+          pending: false,
         }),
         credentials: "include",
       });

--- a/app/(app)/expenses/page.tsx
+++ b/app/(app)/expenses/page.tsx
@@ -16,7 +16,7 @@ export default async function ExpensesPage() {
   if (!user) redirect('/login')
   const { data: expenses } = await supabase
     .from('expenses')
-    .select('id, vendor, description, amount, currency, date')
+    .select('id, vendor, description, amount, currency, date, pending')
     .eq('user_id', user.id)
     .order('date', { ascending: false })
 
@@ -36,7 +36,7 @@ export default async function ExpensesPage() {
         {(expenses ?? []).map((e: any) => (
           <div
             key={e.id}
-            className="grid grid-cols-4 items-center py-2 gap-4"
+            className={`grid grid-cols-4 items-center py-2 gap-4 ${e.pending ? 'bg-orange-100' : ''}`}
           >
             <Link className="underline" href={`/expenses/${e.id}`}>
               {e.date?.slice(0, 10)}

--- a/app/(app)/expenses/snap/page.tsx
+++ b/app/(app)/expenses/snap/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { useState } from "react";
+import { supabase } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
+
+export default function SnapExpensePage() {
+  const [receiptFile, setReceiptFile] = useState<File | null>(null);
+  const [saving, setSaving] = useState(false);
+  const router = useRouter();
+
+  const submit = async () => {
+    if (!receiptFile) return;
+    setSaving(true);
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+      const fileExt = receiptFile.name.split(".").pop() || "jpg";
+      const filePath = `${user.id}/${Date.now()}.${fileExt}`;
+      const { error: uploadError } = await supabase.storage
+        .from("receipts")
+        .upload(filePath, receiptFile);
+      if (uploadError) {
+        console.error("Failed to upload receipt", uploadError);
+      }
+      const res = await fetch("/api/expenses", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          amount: 0,
+          currency: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || "AUD",
+          date: new Date().toISOString(),
+          description: "",
+          vendor: "",
+          category: "",
+          account: "",
+          receipt_url: filePath,
+          pending: true,
+        }),
+        credentials: "include",
+      });
+      if (res.ok) {
+        router.push("/dashboard");
+        router.refresh();
+      } else {
+        console.error("Failed to save expense", await res.json());
+      }
+    } catch (e) {
+      console.error("Failed to save expense", e);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <main className="container py-6">
+      <h1 className="text-xl font-semibold mb-4">Snap expense</h1>
+      <div className="card space-y-3">
+        <input
+          type="file"
+          accept="image/*"
+          capture="environment"
+          onChange={(e) => setReceiptFile(e.target.files?.[0] || null)}
+        />
+        <button
+          onClick={submit}
+          disabled={!receiptFile || saving}
+          className="px-3 py-2 rounded-md border disabled:opacity-50 hover:bg-neutral-100"
+        >
+          {saving ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/app/(app)/exports/new/page.tsx
+++ b/app/(app)/exports/new/page.tsx
@@ -13,6 +13,7 @@ export default async function NewExportPage() {
     .from('expenses')
     .select('id, amount, currency, date, vendor, category')
     .eq('user_id', user.id)
+    .eq('pending', false)
     .is('export_id', null)
     .order('date', { ascending: false })
 

--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -92,7 +92,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
       .eq('user_id', user.id)
       .eq('name', body.account)
       .maybeSingle()
-    if (accountFetchError) {
+  if (accountFetchError) {
       return NextResponse.json({ error: accountFetchError.message }, { status: 400 })
     }
     if (existingAccount) {
@@ -110,7 +110,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     }
   }
 
-  const update = {
+  const update: any = {
     amount,
     currency: body.currency,
     date: dateObj.toISOString(),
@@ -121,6 +121,10 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     category_id,
     account_id,
     receipt_url: body.receipt_url,
+  }
+
+  if (typeof body.pending === 'boolean') {
+    update.pending = body.pending
   }
   const { data, error } = await supabase
     .from('expenses')

--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -101,7 +101,7 @@ export async function POST(req: Request) {
       .eq('user_id', user.id)
       .eq('name', body.account)
       .maybeSingle()
-    if (accountFetchError) {
+  if (accountFetchError) {
       return NextResponse.json({ error: accountFetchError.message }, { status: 400 })
     }
     if (existingAccount) {
@@ -119,6 +119,8 @@ export async function POST(req: Request) {
     }
   }
 
+  const pending = body.pending === true
+
   const insert = {
     amount,
     currency: body.currency,
@@ -131,6 +133,7 @@ export async function POST(req: Request) {
     category_id,
     account_id,
     receipt_url: body.receipt_url,
+    pending,
   }
   const { data, error } = await supabase.from('expenses').insert(insert).select().single()
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })

--- a/app/api/export/csv/route.ts
+++ b/app/api/export/csv/route.ts
@@ -17,6 +17,7 @@ export async function GET(req: Request) {
     .from('expenses')
     .select('id, amount, currency, date, description, vendor, category, receipt_url, export_id')
     .eq('user_id', user.id)
+    .eq('pending', false)
     .gte('date', start).lte('date', end)
     .order('date', { ascending: true })
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })

--- a/app/api/exports/create/route.ts
+++ b/app/api/exports/create/route.ts
@@ -27,6 +27,7 @@ export async function POST(req: Request) {
         .from('expenses')
         .select('id, amount, currency, date, description, vendor, category, receipt_url, export_id')
         .eq('user_id', user.id)
+        .eq('pending', false)
         .in('id', ids)
         .order('date', { ascending: true })
       if (error) {
@@ -45,6 +46,7 @@ export async function POST(req: Request) {
       let q = supabase.from('expenses')
         .select('id, amount, currency, date, description, vendor, category, receipt_url, export_id')
         .eq('user_id', user.id)
+        .eq('pending', false)
         .gte('date', start).lte('date', end)
       if (!includeExported) q = q.is('export_id', null)
       q = q.order('date', { ascending: true })

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -158,6 +158,7 @@ CREATE TABLE IF NOT EXISTS public.expenses (
   date TIMESTAMPTZ DEFAULT NOW(),
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW(),
+  pending BOOLEAN NOT NULL DEFAULT false,
   deleted_at TIMESTAMPTZ
 );
 


### PR DESCRIPTION
## Summary
- support pending expenses in schema and API
- add "Snap expense" flow with camera upload
- highlight pending expenses and exclude them from exports

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d970ae2cc8330b24c65c307ca6c2d