### PR TITLE
Process snap receipts with OpenAI

### DIFF
--- a/app/(app)/expenses/snap/page.tsx
+++ b/app/(app)/expenses/snap/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { supabase } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
+import { parseDateInput } from "@/lib/date";
 
 export default function SnapExpensePage() {
   const [receiptFile, setReceiptFile] = useState<File | null>(null);
@@ -25,27 +26,84 @@ export default function SnapExpensePage() {
         if (uploadError) {
           console.error("Failed to upload receipt", uploadError);
         }
-        const res = await fetch("/api/expenses", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            amount: 0,
-            currency: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || "AUD",
-            date: new Date().toISOString(),
-            description: "",
-            vendor: "",
-            category: "",
-            account: "",
-            receipt_url: filePath,
-            pending: true,
-          }),
-          credentials: "include",
-        });
-        if (!res.ok) {
-          console.error("Failed to save expense", await res.json());
+
+        // Create a placeholder expense
+        let expenseId: string | null = null;
+        try {
+          const createRes = await fetch("/api/expenses", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              amount: 0,
+              currency: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || "AUD",
+              date: new Date().toISOString(),
+              description: "",
+              vendor: "",
+              category: "",
+              account: "",
+              receipt_url: filePath,
+              pending: true,
+            }),
+            credentials: "include",
+          });
+          if (createRes.ok) {
+            const created = await createRes.json();
+            expenseId = created.id;
+          } else {
+            console.error("Failed to save expense", await createRes.json());
+          }
+        } catch (e) {
+          console.error("Failed to save expense", e);
+        }
+
+        // Extract data with OpenAI and update the expense
+        if (expenseId) {
+          try {
+            const formData = new FormData();
+            formData.append("image", receiptFile);
+            const extractRes = await fetch("/api/receipts/extract", {
+              method: "POST",
+              body: formData,
+              credentials: "include",
+            });
+            if (extractRes.ok) {
+              const data = await extractRes.json();
+              const parsedDate = data.date
+                ? parseDateInput(data.date)
+                : null;
+              await fetch(`/api/expenses/${expenseId}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  amount: data.amount ?? 0,
+                  currency:
+                    (data.currency ||
+                      process.env.NEXT_PUBLIC_DEFAULT_CURRENCY ||
+                      "AUD").toUpperCase(),
+                  date: (parsedDate ?? new Date()).toISOString(),
+                  description: data.description || "",
+                  vendor: data.vendor || "",
+                  category: data.category || "",
+                  account: "",
+                  receipt_url: filePath,
+                  pending: false,
+                }),
+                credentials: "include",
+              });
+            } else {
+              console.error(
+                "Failed to extract receipt",
+                await extractRes.json()
+              );
+            }
+          } catch (e) {
+            console.error("Failed to process receipt", e);
+          }
         }
       } catch (e) {
         console.error("Failed to save expense", e);
+      } finally {
+        setSaving(false);
       }
     })();
     router.push("/dashboard");


### PR DESCRIPTION
## Summary
- Create placeholder expense on Snap save
- Extract receipt data via OpenAI and update saved expense

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ebe21c0e08330900098c7a32db794