### PR TITLE
Fix asynchronous expense snapshot creation

### DIFF
--- a/app/(app)/expenses/snap/page.tsx
+++ b/app/(app)/expenses/snap/page.tsx
@@ -9,105 +9,103 @@ export default function SnapExpensePage() {
   const [saving, setSaving] = useState(false);
   const router = useRouter();
 
-  const submit = () => {
+  const submit = async () => {
     if (!receiptFile) return;
     setSaving(true);
-    void (async () => {
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+      const fileExt = receiptFile.name.split(".").pop() || "jpg";
+      const filePath = `${user.id}/${Date.now()}.${fileExt}`;
+      const { error: uploadError } = await supabase.storage
+        .from("receipts")
+        .upload(filePath, receiptFile);
+      if (uploadError) {
+        console.error("Failed to upload receipt", uploadError);
+      }
+
+      // Create a placeholder expense
+      let expenseId: string | null = null;
       try {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-        if (!user) return;
-        const fileExt = receiptFile.name.split(".").pop() || "jpg";
-        const filePath = `${user.id}/${Date.now()}.${fileExt}`;
-        const { error: uploadError } = await supabase.storage
-          .from("receipts")
-          .upload(filePath, receiptFile);
-        if (uploadError) {
-          console.error("Failed to upload receipt", uploadError);
-        }
-
-        // Create a placeholder expense
-        let expenseId: string | null = null;
-        try {
-          const createRes = await fetch("/api/expenses", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              amount: 0,
-              currency: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || "AUD",
-              date: new Date().toISOString(),
-              description: "",
-              vendor: "",
-              category: "",
-              account: "",
-              receipt_url: filePath,
-              pending: true,
-            }),
-            credentials: "include",
-          });
-          if (createRes.ok) {
-            const created = await createRes.json();
-            expenseId = created.id;
-          } else {
-            console.error("Failed to save expense", await createRes.json());
-          }
-        } catch (e) {
-          console.error("Failed to save expense", e);
-        }
-
-        // Extract data with OpenAI and update the expense
-        if (expenseId) {
-          try {
-            const formData = new FormData();
-            formData.append("image", receiptFile);
-            const extractRes = await fetch("/api/receipts/extract", {
-              method: "POST",
-              body: formData,
-              credentials: "include",
-            });
-            if (extractRes.ok) {
-              const data = await extractRes.json();
-              const parsedDate = data.date
-                ? parseDateInput(data.date)
-                : null;
-              await fetch(`/api/expenses/${expenseId}`, {
-                method: "PATCH",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  amount: data.amount ?? 0,
-                  currency:
-                    (data.currency ||
-                      process.env.NEXT_PUBLIC_DEFAULT_CURRENCY ||
-                      "AUD").toUpperCase(),
-                  date: (parsedDate ?? new Date()).toISOString(),
-                  description: data.description || "",
-                  vendor: data.vendor || "",
-                  category: data.category || "",
-                  account: "",
-                  receipt_url: filePath,
-                  pending: false,
-                }),
-                credentials: "include",
-              });
-            } else {
-              console.error(
-                "Failed to extract receipt",
-                await extractRes.json()
-              );
-            }
-          } catch (e) {
-            console.error("Failed to process receipt", e);
-          }
+        const createRes = await fetch("/api/expenses", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            amount: 0,
+            currency: process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || "AUD",
+            date: new Date().toISOString(),
+            description: "",
+            vendor: "",
+            category: "",
+            account: "",
+            receipt_url: filePath,
+            pending: true,
+          }),
+          credentials: "include",
+        });
+        if (createRes.ok) {
+          const created = await createRes.json();
+          expenseId = created.id;
+        } else {
+          console.error("Failed to save expense", await createRes.json());
         }
       } catch (e) {
         console.error("Failed to save expense", e);
-      } finally {
-        setSaving(false);
       }
-    })();
-    router.push("/dashboard");
-    router.refresh();
+
+      // Extract data with OpenAI and update the expense
+      if (expenseId) {
+        try {
+          const formData = new FormData();
+          formData.append("image", receiptFile);
+          const extractRes = await fetch("/api/receipts/extract", {
+            method: "POST",
+            body: formData,
+            credentials: "include",
+          });
+          if (extractRes.ok) {
+            const data = await extractRes.json();
+            const parsedDate = data.date
+              ? parseDateInput(data.date)
+              : null;
+            await fetch(`/api/expenses/${expenseId}`, {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                amount: data.amount ?? 0,
+                currency:
+                  (data.currency ||
+                    process.env.NEXT_PUBLIC_DEFAULT_CURRENCY ||
+                    "AUD").toUpperCase(),
+                date: (parsedDate ?? new Date()).toISOString(),
+                description: data.description || "",
+                vendor: data.vendor || "",
+                category: data.category || "",
+                account: "",
+                receipt_url: filePath,
+                pending: false,
+              }),
+              credentials: "include",
+            });
+          } else {
+            console.error(
+              "Failed to extract receipt",
+              await extractRes.json()
+            );
+          }
+        } catch (e) {
+          console.error("Failed to process receipt", e);
+        }
+      }
+    } catch (e) {
+      console.error("Failed to save expense", e);
+    } finally {
+      setSaving(false);
+      router.push("/dashboard");
+      router.refresh();
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- ensure receipt upload and expense creation complete before navigation
- wait for OpenAI extraction and expense update before returning to dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ec22590448330bf331ad4762c5abe