### PR TITLE
Auto save snap expense photo

### DIFF
--- a/app/(app)/expenses/snap/page.tsx
+++ b/app/(app)/expenses/snap/page.tsx
@@ -5,12 +5,10 @@ import { useRouter } from "next/navigation";
 import { parseDateInput } from "@/lib/date";
 
 export default function SnapExpensePage() {
-  const [receiptFile, setReceiptFile] = useState<File | null>(null);
   const [saving, setSaving] = useState(false);
   const router = useRouter();
 
-  const submit = async () => {
-    if (!receiptFile) return;
+  const submit = async (receiptFile: File) => {
     setSaving(true);
     try {
       const {
@@ -116,15 +114,13 @@ export default function SnapExpensePage() {
           type="file"
           accept="image/*"
           capture="environment"
-          onChange={(e) => setReceiptFile(e.target.files?.[0] || null)}
+          disabled={saving}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) submit(file);
+          }}
         />
-        <button
-          onClick={submit}
-          disabled={!receiptFile || saving}
-          className="px-3 py-2 rounded-md border disabled:opacity-50 hover:bg-neutral-100"
-        >
-          {saving ? "Saving..." : "Save"}
-        </button>
+        {saving && <p>Saving...</p>}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Automatically save snap expenses when an image is selected
- Remove manual save button and show a saving indicator

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ecf489b2c8330999d20111a61b327