### PR TITLE
Redirect to dashboard after editing expense

### DIFF
--- a/app/(app)/expenses/[id]/page.tsx
+++ b/app/(app)/expenses/[id]/page.tsx
@@ -232,7 +232,7 @@ export default function EditExpensePage({ params }: { params: { id: string } }) 
       });
 
       if (res.ok) {
-        router.push("/expenses");
+        router.push("/dashboard");
         router.refresh();
       } else {
         console.error("Failed to save expense", await res.json());


### PR DESCRIPTION
## Summary
- Redirect users to the dashboard after saving an edited expense instead of the expenses list

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ed53c35488330a2a80fbb17fef09a