### PR TITLE
Keep snapped expenses pending until user confirms

### DIFF
--- a/app/(app)/expenses/snap/page.tsx
+++ b/app/(app)/expenses/snap/page.tsx
@@ -65,6 +65,7 @@ export default function SnapExpensePage() {
             const parsedDate = data.date
               ? parseDateInput(data.date)
               : null;
+            // Update fields but keep expense pending until user confirmation
             await fetch(`/api/expenses/${expenseId}`, {
               method: "PATCH",
               headers: { "Content-Type": "application/json" },
@@ -80,7 +81,6 @@ export default function SnapExpensePage() {
                 category: data.category || "",
                 account: "",
                 receipt_url: filePath,
-                pending: false,
               }),
               credentials: "include",
             });


### PR DESCRIPTION
## Summary
- ensure snap workflow leaves new expenses in pending state
- annotate snap workflow to clarify manual confirmation step

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ed9f9346083308bd4a34362a78a6c