### PR TITLE
Add toggle to reveal unclaimed expense details

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { serverClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
+import UnclaimedExpenses from '@/components/UnclaimedExpenses'
 
 export const revalidate = 0
 
@@ -79,20 +80,7 @@ export default async function DashboardPage() {
           <h2 className="font-semibold mb-2">Unclaimed Expenses</h2>
           <p className="text-sm">Total value: {aud.format(total)}</p>
           <p className="text-sm">Total expenses: {count}</p>
-          <ul className="mt-2 grid gap-3">
-            {list.map((e: any) => (
-              <li key={e.id}>
-                <Link href={`/expenses/${e.id}`} className="card block">
-                  <div className="grid grid-cols-2 gap-x-2 gap-y-1 text-sm">
-                    <span>{e.date?.slice(0, 10)}</span>
-                    <span className="justify-self-end">{aud.format(e.amount)}</span>
-                    <span className="col-span-2">{e.vendor || '—'}</span>
-                    <span className="col-span-2">{e.description || '—'}</span>
-                  </div>
-                </Link>
-              </li>
-            ))}
-          </ul>
+          <UnclaimedExpenses list={list} />
           <Link
             href="/exports/new"
             className="px-3 py-2 rounded-md border block text-center mt-2 bg-red-600 text-white hover:bg-red-700"

--- a/components/UnclaimedExpenses.tsx
+++ b/components/UnclaimedExpenses.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useState } from 'react'
+import Link from 'next/link'
+
+const aud = new Intl.NumberFormat('en-AU', {
+  style: 'currency',
+  currency: 'AUD',
+})
+
+interface Expense {
+  id: string
+  description: string | null
+  vendor: string | null
+  amount: number
+  currency: string
+  date: string | null
+}
+
+export default function UnclaimedExpenses({ list }: { list: Expense[] }) {
+  const [show, setShow] = useState(false)
+
+  if (list.length === 0) return null
+
+  return (
+    <>
+      <button
+        onClick={() => setShow(!show)}
+        className="mt-2 text-sm text-blue-600 underline"
+      >
+        {show ? 'Hide expenses' : 'Show expenses'}
+      </button>
+      {show && (
+        <ul className="mt-2 grid gap-3">
+          {list.map((e) => (
+            <li key={e.id}>
+              <Link href={`/expenses/${e.id}`} className="card block">
+                <div className="grid grid-cols-2 gap-x-2 gap-y-1 text-sm">
+                  <span>{e.date?.slice(0, 10)}</span>
+                  <span className="justify-self-end">{aud.format(e.amount)}</span>
+                  <span className="col-span-2">{e.vendor || '—'}</span>
+                  <span className="col-span-2">{e.description || '—'}</span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add client component to toggle visibility of unclaimed expenses
- hide unclaimed expense list until toggle is activated

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ee268957c8330ac54f291f6ae96c4