### PR TITLE
Fix export expenses page layout

### DIFF
--- a/app/(app)/exports/new/ExportExpenses.tsx
+++ b/app/(app)/exports/new/ExportExpenses.tsx
@@ -34,10 +34,15 @@ export default function ExportExpenses({ initialExpenses, userEmail }:{ initialE
       <h1 className="text-xl font-semibold mb-4">Export expenses</h1>
       <div className="card space-y-4">
         <input type="email" placeholder="Email" value={email} onChange={e=> setEmail(e.target.value)} />
-        <div className="max-h-64 overflow-y-auto divide-y">
+        <div className="divide-y">
           {initialExpenses.map(e => (
             <label key={e.id} className="flex items-center gap-2 py-2 text-sm">
-              <input type="checkbox" checked={selected.includes(e.id)} onChange={() => toggle(e.id)} />
+              <input
+                type="checkbox"
+                className="w-4 h-4"
+                checked={selected.includes(e.id)}
+                onChange={() => toggle(e.id)}
+              />
               <span className="flex-1">{e.vendor || '—'} — {e.category || '—'} — {e.amount} {e.currency}</span>
             </label>
           ))}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -7,7 +7,17 @@
 html, body { margin: 0; padding: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial; }
 .container { max-width: 960px; margin: 0 auto; padding: 1rem; }
 .card { border: 1px solid rgba(0,0,0,.1); border-radius: 16px; padding: 1rem; }
-input, button, textarea, select { width: 100%; padding:.6rem; border-radius:12px; border:1px solid rgba(0,0,0,.15); }
+input:not([type='checkbox']):not([type='radio']), button, textarea, select {
+  width: 100%;
+  padding: .6rem;
+  border-radius: 12px;
+  border: 1px solid rgba(0,0,0,.15);
+}
+input[type='checkbox'],
+input[type='radio'] {
+  width: auto;
+  padding: 0;
+}
 button { cursor: pointer; }
 pre { overflow: auto; background: rgba(0,0,0,.04); padding: .75rem; border-radius: 12px; }
 .sb-2 { box-shadow: 0 2px 4px rgba(0,0,0,.08); }


### PR DESCRIPTION
## Summary
- avoid oversized checkboxes by excluding them from global width & padding
- simplify export expenses list layout for clearer one-line items

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ee4c8f44c8330b381c796a407aee3