### PR TITLE
feat: promote snap expense button

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -45,18 +45,20 @@ export default async function DashboardPage() {
   return (
     <main className="container py-6">
       <div className="grid gap-3">
-        <Link
-          href="/expenses/new"
-          className="px-3 py-2 rounded-md border block text-center bg-green-600 text-white hover:bg-green-700"
-        >
-          Add expense
-        </Link>
-        <Link
-          href="/expenses/snap"
-          className="px-3 py-2 rounded-md border block text-center bg-blue-600 text-white hover:bg-blue-700"
-        >
-          Snap expense
-        </Link>
+        <div className="grid grid-cols-2 gap-3">
+          <Link
+            href="/expenses/new"
+            className="px-3 py-2 rounded-md border block text-center hover:bg-neutral-100"
+          >
+            Add manual expense
+          </Link>
+          <Link
+            href="/expenses/snap"
+            className="px-3 py-2 rounded-md border block text-center bg-green-600 text-white hover:bg-green-700"
+          >
+            Snap expense
+          </Link>
+        </div>
         <div className="card">
           <h2 className="font-semibold mb-2">Unconfirmed Expenses</h2>
           <p className="text-sm">Total value: {aud.format(pendingTotal)}</p>

--- a/app/(app)/expenses/new/page.tsx
+++ b/app/(app)/expenses/new/page.tsx
@@ -227,7 +227,7 @@ export default function NewExpensePage() {
 
   return (
     <main className="container py-6">
-      <h1 className="text-xl font-semibold mb-4">Add expense</h1>
+      <h1 className="text-xl font-semibold mb-4">Add manual expense</h1>
       <div className="card space-y-3">
         <div>
           <input


### PR DESCRIPTION
## Summary
- show snapshot and manual expense actions side by side on dashboard
- style Snap expense as primary and Add manual expense as secondary
- rename manual expense page header

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ee8577fd48330a2415991e683dc64