### PR TITLE
Add snap expense button

### DIFF
--- a/app/(app)/expenses/snap/page.tsx
+++ b/app/(app)/expenses/snap/page.tsx
@@ -2,9 +2,11 @@
 import { supabase } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import { parseDateInput } from "@/lib/date";
+import { useRef } from "react";
 
 export default function SnapExpensePage() {
   const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const saveExpense = async (receiptFile: File) => {
     try {
@@ -112,6 +114,7 @@ export default function SnapExpensePage() {
       <h1 className="text-xl font-semibold mb-4">Snap expense</h1>
       <div className="card space-y-3">
         <input
+          ref={fileInputRef}
           type="file"
           accept="image/*"
           capture="environment"
@@ -119,7 +122,14 @@ export default function SnapExpensePage() {
             const file = e.target.files?.[0];
             if (file) submit(file);
           }}
+          className="hidden"
         />
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="px-3 py-2 rounded-md border block text-center bg-green-600 text-white hover:bg-green-700"
+        >
+          Snap expense
+        </button>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Add a button on the Snap Expense page that triggers the camera/file picker
- Hide the file input and control it via `useRef`

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689eeaf674888330a60f9f9896a1cb07