### PR TITLE
Auto-open camera on snap expense

### DIFF
--- a/app/(app)/expenses/snap/page.tsx
+++ b/app/(app)/expenses/snap/page.tsx
@@ -2,11 +2,15 @@
 import { supabase } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import { parseDateInput } from "@/lib/date";
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 
 export default function SnapExpensePage() {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    fileInputRef.current?.click();
+  }, []);
 
   const saveExpense = async (receiptFile: File) => {
     try {


### PR DESCRIPTION
## Summary
- Automatically trigger camera capture when navigating to the Snap Expense page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689eed1e14508330ba574706bf56f813