### PR TITLE
fix dark mode input styles

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -12,6 +12,8 @@ input:not([type='checkbox']):not([type='radio']), button, textarea, select {
   padding: .6rem;
   border-radius: 12px;
   border: 1px solid rgba(0,0,0,.15);
+  background-color: #fff;
+  color: #000;
 }
 input[type='checkbox'],
 input[type='radio'] {
@@ -21,3 +23,24 @@ input[type='radio'] {
 button { cursor: pointer; }
 pre { overflow: auto; background: rgba(0,0,0,.04); padding: .75rem; border-radius: 12px; }
 .sb-2 { box-shadow: 0 2px 4px rgba(0,0,0,.08); }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #fff;
+    background-color: #000;
+  }
+
+  .card {
+    border: 1px solid rgba(255,255,255,.1);
+  }
+
+  pre {
+    background: rgba(255,255,255,.04);
+  }
+
+  input:not([type='checkbox']):not([type='radio']), textarea, select {
+    background-color: #1f2937;
+    color: #fff;
+    border: 1px solid rgba(255,255,255,.15);
+  }
+}


### PR DESCRIPTION
## Summary
- ensure text and background colors for form fields remain readable in dark mode
- add basic dark theme styles for cards and body

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ef2001e84833095d8f4dc88aef974