### PR TITLE
feat: toggle exported expenses

### DIFF
--- a/app/(app)/expenses/ExportsPane.tsx
+++ b/app/(app)/expenses/ExportsPane.tsx
@@ -16,7 +16,12 @@ export default function ExportsPane() {
 
   return (
     <>
-      <button onClick={() => setOpen(true)} className="underline">Exports</button>
+      <button
+        onClick={() => setOpen(true)}
+        className="px-3 py-2 rounded-md border text-sm text-neutral-600"
+      >
+        Exports
+      </button>
       <div className={`fixed top-0 right-0 h-full w-80 bg-white border-l shadow-lg transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}>
         <div className="p-4 h-full flex flex-col">
           <button onClick={() => setOpen(false)} className="underline mb-2">Close</button>

--- a/app/(app)/expenses/page.tsx
+++ b/app/(app)/expenses/page.tsx
@@ -16,16 +16,58 @@ export default async function ExpensesPage() {
   if (!user) redirect('/login')
   const { data: expenses } = await supabase
     .from('expenses')
-    .select('id, vendor, description, amount, currency, date, pending')
+    .select('id, vendor, description, amount, currency, date, pending, export_id')
     .eq('user_id', user.id)
     .order('date', { ascending: false })
 
+  const unexported = (expenses ?? []).filter((e: any) => !e.export_id)
+  const exported = (expenses ?? []).filter((e: any) => e.export_id)
+
   return (
     <main className="container py-6">
-      <div className="flex justify-between items-center mb-4">
+      <div className="flex items-center mb-4">
         <h1 className="text-xl font-semibold">Expenses</h1>
-        <ExportsPane />
+        <div className="ml-auto">
+          <ExportsPane />
+        </div>
       </div>
+      <details className="mb-4">
+        <summary className="cursor-pointer underline text-sm text-neutral-600 mb-2">
+          Show exported expenses
+        </summary>
+        <div className="mt-2">
+          <div className="grid grid-cols-4 gap-4 pb-2 font-medium text-sm">
+            <div>Date</div>
+            <div>Vendor</div>
+            <div>Description</div>
+            <div className="justify-self-end">Amount</div>
+          </div>
+          <div className="divide-y mb-4">
+            {exported.map((e: any) => (
+              <div
+                key={e.id}
+                className="grid grid-cols-4 items-center py-2 gap-4"
+              >
+                <Link className="underline" href={`/expenses/${e.id}`}>
+                  {e.date?.slice(0, 10)}
+                </Link>
+                <Link className="underline" href={`/expenses/${e.id}`}>
+                  {e.vendor || '—'}
+                </Link>
+                <Link className="underline" href={`/expenses/${e.id}`}>
+                  {e.description || '—'}
+                </Link>
+                <Link className="underline justify-self-end" href={`/expenses/${e.id}`}>
+                  {aud.format(e.amount)}
+                </Link>
+              </div>
+            ))}
+            {!exported.length && (
+              <p className="text-sm text-neutral-600">No exported expenses</p>
+            )}
+          </div>
+        </div>
+      </details>
       <div className="grid grid-cols-4 gap-4 pb-2 font-medium text-sm">
         <div>Date</div>
         <div>Vendor</div>
@@ -33,7 +75,7 @@ export default async function ExpensesPage() {
         <div className="justify-self-end">Amount</div>
       </div>
       <div className="divide-y">
-        {(expenses ?? []).map((e: any) => (
+        {unexported.map((e: any) => (
           <div
             key={e.id}
             className={`grid grid-cols-4 items-center py-2 gap-4 ${e.pending ? 'bg-orange-100' : ''}`}
@@ -52,6 +94,9 @@ export default async function ExpensesPage() {
             </Link>
           </div>
         ))}
+        {!unexported.length && (
+          <p className="text-sm text-neutral-600">No expenses</p>
+        )}
       </div>
     </main>
   )


### PR DESCRIPTION
## Summary
- hide exported expenses behind toggle above main list
- style Exports button with secondary color and right alignment

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fb354134083309f383b3de07bc0a6