### PR TITLE
Simplify export preview period display

### DIFF
--- a/app/(app)/expenses/ExportsPane.tsx
+++ b/app/(app)/expenses/ExportsPane.tsx
@@ -56,8 +56,8 @@ export default function ExportsPane() {
             {exports.map((e: any) => (
               <div key={e.id} className="card">
                 <button onClick={() => toggle(e.id)} className="text-left w-full">
-                  <div>Period: {e.period_start} → {e.period_end}</div>
-                  <div>Items: {e.items_count} • Total: {e.total_amount} {e.currency}</div>
+                  <div>Period: {e.period_end.slice(0, 10)}</div>
+                  <div>Transactions: {e.items_count} • Total: {e.total_amount} {e.currency}</div>
                 </button>
                 {files[e.id] && (
                   <div className="mt-2 text-sm">


### PR DESCRIPTION
## Summary
- show export history entries with only the end date as the period
- display transaction count and total value without timestamps

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fb963e3dc8330b723b0cfd443ad4d