### PR TITLE
feat: add profile dropdown

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import Menu from './Menu'
+import ProfileDropdown from './ProfileDropdown'
 import { serverClient } from '@/lib/supabase/server'
 
 export default async function Header() {
@@ -23,14 +24,7 @@ export default async function Header() {
           </Link>
         </div>
         <div className="flex items-center gap-3">
-          {user && (
-            <div className="flex items-center gap-2 sb-2">
-              <div className="w-8 h-8 rounded-full bg-neutral-200 flex items-center justify-center text-sm font-medium">
-                {name?.slice(0, 1).toUpperCase()}
-              </div>
-              <span className="text-sm hidden sm:inline">{name}</span>
-            </div>
-          )}
+          {user && <ProfileDropdown name={name} />}
         </div>
       </div>
     </header>

--- a/components/Menu.tsx
+++ b/components/Menu.tsx
@@ -69,13 +69,6 @@ export default function Menu() {
             </Link>
           </div>
         </details>
-        <Link
-          href="/settings"
-          className="block px-4 py-2 hover:bg-neutral-100"
-          onClick={() => setOpen(false)}
-        >
-          Profile
-        </Link>
         <LogoutButton
           className="block w-full text-left px-4 py-2 hover:bg-neutral-100"
         />

--- a/components/ProfileDropdown.tsx
+++ b/components/ProfileDropdown.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+
+export default function ProfileDropdown({ name }: { name: string }) {
+  const [open, setOpen] = useState(false)
+  const initial = name.slice(0, 1).toUpperCase()
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-2"
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        <div className="w-8 h-8 rounded-full bg-neutral-200 flex items-center justify-center text-sm font-medium">
+          {initial}
+        </div>
+        <span className="text-sm hidden sm:inline">{name}</span>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-40 bg-white sb-2 z-50">
+          <Link
+            href="/settings"
+            className="block px-4 py-2 text-sm hover:bg-neutral-100"
+            onClick={() => setOpen(false)}
+          >
+            Profile
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add profile dropdown from avatar with link to profile settings
- remove profile link from side menu

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fc9a1b5848330b74ab513269fcc38