### PR TITLE
feat: add default currency dropdown

### DIFF
--- a/app/(app)/settings/SettingsForm.tsx
+++ b/app/(app)/settings/SettingsForm.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState } from 'react'
+import { supabase } from '@/lib/supabase/client'
+
+interface Settings {
+  defaultCurrency: string
+  enabledCurrencies: string[]
+}
+
+export default function SettingsForm({
+  userId,
+  initialSettings,
+}: {
+  userId: string
+  initialSettings: Settings
+}) {
+  const [currency, setCurrency] = useState(initialSettings.defaultCurrency)
+  const [saving, setSaving] = useState(false)
+
+  const save = async () => {
+    setSaving(true)
+    const newSettings = { ...initialSettings, defaultCurrency: currency }
+    await supabase
+      .from('profiles')
+      .update({ settings: newSettings })
+      .eq('id', userId)
+    setSaving(false)
+  }
+
+  return (
+    <div className="card space-y-3">
+      <div>
+        <label className="block mb-1">Default currency</label>
+        <select
+          value={currency}
+          onChange={(e) => setCurrency(e.target.value)}
+        >
+          {initialSettings.enabledCurrencies.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button
+        onClick={save}
+        disabled={saving}
+        className="px-3 py-2 rounded-md border disabled:opacity-50 hover:bg-neutral-100"
+      >
+        {saving ? 'Saving...' : 'Save'}
+      </button>
+    </div>
+  )
+}

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,19 +1,22 @@
 import { serverClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
+import SettingsForm from './SettingsForm'
 
 export default async function SettingsPage() {
   const supabase = serverClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/login')
-  const { data: profile } = await supabase.from('profiles').select('*').eq('id', user.id).maybeSingle()
-  const settings = profile?.settings || { defaultCurrency: 'AUD', enabledCurrencies: ['AUD','NZD']}
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('settings')
+    .eq('id', user.id)
+    .maybeSingle()
+  const settings =
+    profile?.settings || { defaultCurrency: 'AUD', enabledCurrencies: ['AUD', 'NZD'] }
   return (
     <main className="container py-6">
       <h1 className="text-xl font-semibold mb-4">Settings</h1>
-      <div className="card">
-        <pre>{JSON.stringify(settings, null, 2)}</pre>
-        <p className="text-sm text-neutral-600 mt-2">Edit UI not implemented in scaffold.</p>
-      </div>
+      <SettingsForm userId={user.id} initialSettings={settings} />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- add settings form with default currency selection
- render new settings form on settings page

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fcd09edf08330b74e74b28d24335a