### PR TITLE
feat: allow adding user currencies

### DIFF
--- a/app/(app)/settings/SettingsForm.tsx
+++ b/app/(app)/settings/SettingsForm.tsx
@@ -16,11 +16,26 @@ export default function SettingsForm({
   initialSettings: Settings
 }) {
   const [currency, setCurrency] = useState(initialSettings.defaultCurrency)
+  const [currencies, setCurrencies] = useState(
+    initialSettings.enabledCurrencies
+  )
+  const [newCurrency, setNewCurrency] = useState('')
   const [saving, setSaving] = useState(false)
+
+  const addCurrency = () => {
+    const value = newCurrency.trim().toUpperCase()
+    if (!value || currencies.includes(value)) return
+    setCurrencies([...currencies, value])
+    setNewCurrency('')
+  }
 
   const save = async () => {
     setSaving(true)
-    const newSettings = { ...initialSettings, defaultCurrency: currency }
+    const newSettings = {
+      ...initialSettings,
+      defaultCurrency: currency,
+      enabledCurrencies: currencies,
+    }
     await supabase
       .from('profiles')
       .update({ settings: newSettings })
@@ -36,12 +51,35 @@ export default function SettingsForm({
           value={currency}
           onChange={(e) => setCurrency(e.target.value)}
         >
-          {initialSettings.enabledCurrencies.map((c) => (
+          {currencies.map((c) => (
             <option key={c} value={c}>
               {c}
             </option>
           ))}
         </select>
+      </div>
+      <div>
+        <label className="block mb-1">Enabled currencies</label>
+        <ul className="mb-2 list-disc list-inside">
+          {currencies.map((c) => (
+            <li key={c}>{c}</li>
+          ))}
+        </ul>
+        <div className="flex gap-2">
+          <input
+            value={newCurrency}
+            onChange={(e) => setNewCurrency(e.target.value)}
+            className="border px-2 py-1 rounded"
+            placeholder="Add currency"
+          />
+          <button
+            type="button"
+            onClick={addCurrency}
+            className="px-3 py-1 border rounded"
+          >
+            Add
+          </button>
+        </div>
       </div>
       <button
         onClick={save}


### PR DESCRIPTION
## Summary
- show user currency list and allow adding more
- save enabled currencies along with default selection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fd364a3648330b2beec88055ddc3a