### PR TITLE
feat(settings): persist enabled currencies

### DIFF
--- a/app/(app)/settings/SettingsForm.tsx
+++ b/app/(app)/settings/SettingsForm.tsx
@@ -108,14 +108,21 @@ export default function SettingsForm({
   const save = async () => {
     setSaving(true)
     const newSettings = {
-      ...initialSettings,
       defaultCurrency: currency,
-      enabledCurrencies: currencies,
     }
     await supabase
       .from('profiles')
       .update({ settings: newSettings })
       .eq('id', userId)
+    await supabase
+      .from('user_currencies')
+      .delete()
+      .eq('user_id', userId)
+    if (currencies.length) {
+      await supabase
+        .from('user_currencies')
+        .insert(currencies.map((c) => ({ user_id: userId, currency: c })))
+    }
     setSaving(false)
   }
 

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -11,8 +11,14 @@ export default async function SettingsPage() {
     .select('settings')
     .eq('id', user.id)
     .maybeSingle()
-  const settings =
-    profile?.settings || { defaultCurrency: 'AUD', enabledCurrencies: ['AUD', 'NZD'] }
+  const { data: enabled } = await supabase
+    .from('user_currencies')
+    .select('currency')
+    .eq('user_id', user.id)
+  const settings = {
+    defaultCurrency: profile?.settings?.defaultCurrency || 'AUD',
+    enabledCurrencies: enabled?.map((c) => c.currency) || ['AUD', 'NZD'],
+  }
   return (
     <main className="container py-6">
       <h1 className="text-xl font-semibold mb-4">Settings</h1>


### PR DESCRIPTION
## Summary
- add user_currencies table with RLS policies and default currency insertion
- read and update enabled currencies via new table in settings UI

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fde8e59d4833098ed2ab90743be19