### PR TITLE
Prompt user to set default currency on first login

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,6 +1,22 @@
 import Header from '@/components/Header'
+import { serverClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const supabase = serverClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (session?.user) {
+    const { data } = await supabase
+      .from('profiles')
+      .select('settings')
+      .eq('id', session.user.id)
+      .single()
+    if (!data?.settings?.defaultCurrency) {
+      redirect('/select-currency')
+    }
+  }
   return (
     <>
       <Header />

--- a/app/select-currency/SelectCurrencyForm.tsx
+++ b/app/select-currency/SelectCurrencyForm.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { supabase } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
+
+export default function SelectCurrencyForm() {
+  const [currency, setCurrency] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const save = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const code = currency.trim().toUpperCase();
+      const res = await fetch("https://api.frankfurter.dev/v1/currencies");
+      const data = await res.json();
+      if (!data[code]) {
+        throw new Error("Invalid currency code");
+      }
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error("Not authenticated");
+      const settings = { defaultCurrency: code, enabledCurrencies: [code] };
+      const { error: upErr } = await supabase
+        .from("profiles")
+        .update({ settings })
+        .eq("id", user.id);
+      if (upErr) throw upErr;
+      await supabase.from("user_currencies").insert({ user_id: user.id, currency: code });
+      router.push("/dashboard");
+    } catch (e: any) {
+      setError(e.message || "Error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="container py-10">
+      <div className="max-w-md mx-auto card space-y-3">
+        <h1 className="text-2xl font-semibold mb-4">Choose your currency</h1>
+        <input
+          placeholder="Currency code (e.g. AUD)"
+          value={currency}
+          onChange={(e) => setCurrency(e.target.value)}
+        />
+        <button
+          onClick={save}
+          disabled={loading}
+          className="bg-black text-white py-2 rounded-md"
+        >
+          {loading ? "Saving..." : "Save"}
+        </button>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+      </div>
+    </main>
+  );
+}

--- a/app/select-currency/page.tsx
+++ b/app/select-currency/page.tsx
@@ -1,0 +1,14 @@
+import { redirect } from "next/navigation";
+import SelectCurrencyForm from "./SelectCurrencyForm";
+import { serverClient } from "@/lib/supabase/server";
+
+export default async function Page() {
+  const supabase = serverClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) {
+    redirect("/login?redirect=/select-currency");
+  }
+  return <SelectCurrencyForm />;
+}


### PR DESCRIPTION
## Summary
- redirect authenticated users without a default currency to a new selection flow
- allow choosing and validating a default currency with the Frankfurter API
- relax profile currency defaults in schema to await user choice

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fe0ff3b3c8330bddcfc7c837da50d