### PR TITLE
Fix initial currency setup not saving

### DIFF
--- a/app/select-currency/SelectCurrencyForm.tsx
+++ b/app/select-currency/SelectCurrencyForm.tsx
@@ -27,10 +27,15 @@ export default function SelectCurrencyForm() {
       const settings = { defaultCurrency: code, enabledCurrencies: [code] };
       const { error: upErr } = await supabase
         .from("profiles")
-        .update({ settings })
-        .eq("id", user.id);
+        .upsert({ id: user.id, settings }, { onConflict: "id" });
       if (upErr) throw upErr;
-      await supabase.from("user_currencies").insert({ user_id: user.id, currency: code });
+      const { error: curErr } = await supabase
+        .from("user_currencies")
+        .upsert(
+          { user_id: user.id, currency: code },
+          { onConflict: "user_id,currency" }
+        );
+      if (curErr) throw curErr;
       router.push("/dashboard");
     } catch (e: any) {
       setError(e.message || "Error");


### PR DESCRIPTION
## Summary
- ensure currency selection persists by upserting profile and user_currencies entries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fe36d7b8483309f4cda56d3bfe127