### PR TITLE
Refine currency list layout in settings

### DIFF
--- a/app/(app)/settings/SettingsForm.tsx
+++ b/app/(app)/settings/SettingsForm.tsx
@@ -168,11 +168,12 @@ export default function SettingsForm({
           <>
             <ul className="mb-2 list-disc list-inside">
               {sortedCurrencies.map((c) => (
-                <li key={c}>
-                  {c}
+                <li key={c} className="flex justify-between">
+                  <span>{c}:</span>
                   {currencyInfo[c] && (
                     <>
-                      {`: ${currencyInfo[c].name}: 1 ${currency} = ${currencyInfo[c].rate.toFixed(4)} ${c}`}
+                      <span className="flex-1 text-center">{currencyInfo[c].name}:</span>
+                      <span className="text-right">{`1 ${currency} = ${currencyInfo[c].rate.toFixed(4)} ${c}`}</span>
                     </>
                   )}
                 </li>


### PR DESCRIPTION
## Summary
- show enabled currencies with code, name, and exchange rate in separate columns

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fecf1c9088330affeaf008782ae70