### PR TITLE
Display expense totals in user's default currency

### DIFF
--- a/components/UnclaimedExpenses.tsx
+++ b/components/UnclaimedExpenses.tsx
@@ -3,10 +3,13 @@
 import { useState } from 'react'
 import Link from 'next/link'
 
-const aud = new Intl.NumberFormat('en-AU', {
-  style: 'currency',
-  currency: 'AUD',
-})
+interface Props {
+  list: Expense[]
+  currency: string
+}
+
+const format = (currency: string) =>
+  new Intl.NumberFormat('en', { style: 'currency', currency })
 
 interface Expense {
   id: string
@@ -17,8 +20,9 @@ interface Expense {
   date: string | null
 }
 
-export default function UnclaimedExpenses({ list }: { list: Expense[] }) {
+export default function UnclaimedExpenses({ list, currency }: Props) {
   const [show, setShow] = useState(false)
+  const fmt = format(currency)
 
   if (list.length === 0) return null
 
@@ -37,7 +41,7 @@ export default function UnclaimedExpenses({ list }: { list: Expense[] }) {
               <Link href={`/expenses/${e.id}`} className="card block">
                 <div className="grid grid-cols-2 gap-x-2 gap-y-1 text-sm">
                   <span>{e.date?.slice(0, 10)}</span>
-                  <span className="justify-self-end">{aud.format(e.amount)}</span>
+                  <span className="justify-self-end">{fmt.format(e.amount)}</span>
                   <span className="col-span-2">{e.vendor || '—'}</span>
                   <span className="col-span-2">{e.description || '—'}</span>
                 </div>

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -1,0 +1,35 @@
+export interface CurrencyExpense {
+  amount: number
+  currency: string
+}
+
+// Convert array of expenses to target currency using Frankfurter API
+export async function convertExpenses<T extends CurrencyExpense>(
+  expenses: T[],
+  target: string
+): Promise<T[]> {
+  const uniqueCurrencies = Array.from(
+    new Set(expenses.map((e) => e.currency))
+  ).filter((c) => c !== target)
+  const rates: Record<string, number> = {}
+  await Promise.all(
+    uniqueCurrencies.map(async (c) => {
+      try {
+        const res = await fetch(
+          `https://api.frankfurter.dev/v1/latest?from=${c}&to=${target}`
+        )
+        const data = await res.json()
+        const rate = data.rates?.[target]
+        if (typeof rate === 'number') rates[c] = rate
+      } catch {
+        // if fetch fails, default to 1 (no conversion)
+        rates[c] = 1
+      }
+    })
+  )
+  return expenses.map((e) => ({
+    ...e,
+    amount: e.amount * (rates[e.currency] ?? 1),
+    currency: target,
+  }))
+}


### PR DESCRIPTION
## Summary
- convert expenses to user-selected default currency using Frankfurter API
- show dashboard and expense listings in the default currency
- support currency-aware formatting in UnclaimedExpenses component

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ff3e2ebc48330bdf497beda019534